### PR TITLE
fix: update-repo should not proceed if change failed

### DIFF
--- a/lib/update-repo.js
+++ b/lib/update-repo.js
@@ -54,16 +54,27 @@ async function processRepository(
   let cloneUrl = repository.getRepository()['clone_url'];
   await exec(`git clone ${cloneUrl} ${tmpDir.path}`);
 
-  let filesToUpdate = await updateCallback(tmpDir.path);
+  let filesToUpdate;
+  try {
+    filesToUpdate = await updateCallback(tmpDir.path);
+  } catch (err) {
+    console.warn(
+      '  callback function threw an exception, skipping this repository'
+    );
+    return;
+  }
+
   if (filesToUpdate === undefined) {
     console.warn(
       '  callback function returned undefined value, skipping this repository'
     );
+    return;
   }
   if (filesToUpdate.length === 0) {
     console.warn(
       '  callback function returned empty list, skipping this repository'
     );
+    return;
   }
 
   let latestCommit;

--- a/test/update-repo.js
+++ b/test/update-repo.js
@@ -372,6 +372,7 @@ describe('UpdateRepo', () => {
     } catch (err) {
       // ignore
     }
+    assert.equal(FakeGitHub.repository.branches[branch], undefined);
   });
 
   it('should not perform update if updateCallback returned empty list', async () => {
@@ -390,5 +391,25 @@ describe('UpdateRepo', () => {
     } catch (err) {
       // ignore
     }
+    assert.equal(FakeGitHub.repository.branches[branch], undefined);
+  });
+
+  it('should not perform update if updateCallback promise was rejected', async () => {
+    try {
+      await suppressConsole(async () => {
+        await updateRepo({
+          updateCallback: () => {
+            return Promise.reject();
+          },
+          branch,
+          message,
+          comment,
+        });
+      });
+      assert(false);
+    } catch (err) {
+      // ignore
+    }
+    assert.equal(FakeGitHub.repository.branches[branch], undefined);
   });
 });


### PR DESCRIPTION
`update-repo` clones each repository and executes the user-provided function to apply any needed changes to each repository, and commits the results. If this function fails, we don't need to proceed with this particular repo.