### PR TITLE
chore: explicitly set gitAuthor to null to make CLA bot happy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,5 +13,6 @@
     "schedule": [
       "before 10am on tuesday"
     ]
-  }
+  },
+  "gitAuthor": null
 }


### PR DESCRIPTION
It's configured for this repo by @rarkins but as I'd like to use this `renovate.json` as a template for future repos, let's put it in explicitly.