### PR TITLE
docs: a sample for lock files maintenance

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -4,6 +4,13 @@ While we don't have a good documented samples (yet), this folder contains
 scripts that were used to solve some problems related to managing multiple
 repositories, and can be used as examples of using the library.
 
+### `lock-file-maintenance.sh`
+
+A sample shell script that can be passed to `apply-change.js`. This script
+updates `package-lock.json` and `samples/package-lock.json` (if the latter
+exists) to make the package use the latest dependencies. It also verifies that
+the samples package depends on the current version of the main package.
+
 ### `fix-samples-dependency.sh`
 
 A sample shell script that can be passed to `apply-change.js`. This particular

--- a/samples/lock-files-maintenance.sh
+++ b/samples/lock-files-maintenance.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# @fileoverview Update package-lock.json in both the main package and
+# the samples package. Also, verify that samples depend on the correct
+# version of the main package.
+# Requires `jq` tool to be installed (https://stedolan.github.io/jq/).
+# Pass this script as a parameter to `apply-change.js`.
+
+rm -f package-lock.json
+if test -f samples/package.json ; then
+  main_name=`jq -r .name package.json`
+  main_version=`jq -r .version package.json`
+  samples_dependency=`jq -r ".dependencies.\"$main_name\"" samples/package.json`
+  if [ "$main_version" == "$samples_dependency" ]; then
+      echo "Samples version is good."
+  else
+    echo "Making changes! Current version of $main_name is $main_version, samples depend on version $samples_dependency."
+    jq -r ".dependencies.\"$main_name\"=\"$main_version\"" samples/package.json > samples/package.json.new
+    mv samples/package.json.new samples/package.json
+  fi
+
+  rm -f samples/package-lock.json
+fi
+
+npm install
+npm link
+if test -f samples/package.json ; then
+  cd samples
+  npm link ../
+  npm install
+  cd ..
+fi
+
+echo "Git status:"
+git status
+echo "Done!"
+exit 0


### PR DESCRIPTION
I have just used this script to update `package-lock.json` and `samples/package-lock.json` in all our packages (since we use a little bit weird way of handling samples package and `npm link` to make it work, we can't (yet) make Greenkeeper or Renovate work for us in the way we expect). 