### PR TITLE
fix: clean up tests and config types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test.js
 config.yaml
 ignored
 build
+.vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,21 +5,21 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.49.tgz",
-      "integrity": "sha1-vs2AVIJzREDJ0TfkbXc0DmTX9Rs=",
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.51.tgz",
+      "integrity": "sha1-vXHZsZKvl435FYKdOdQJRFZDmgw=",
       "dev": true,
       "requires": {
-        "@babel/highlight": "7.0.0-beta.49"
+        "@babel/highlight": "7.0.0-beta.51"
       }
     },
     "@babel/generator": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.49.tgz",
-      "integrity": "sha1-6c/9qROZaszseTu8JauRvBnQv3o=",
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.51.tgz",
+      "integrity": "sha1-bHV1/952HQdIXgS67cA5LG2eMPY=",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.49",
+        "@babel/types": "7.0.0-beta.51",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.5",
         "source-map": "^0.5.0",
@@ -35,38 +35,38 @@
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.49.tgz",
-      "integrity": "sha1-olwRGbnwNSeGcBJuAiXAMEHI3jI=",
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.51.tgz",
+      "integrity": "sha1-IbSHSiJ8+Z7K/MMKkDAtpaJkBWE=",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.49",
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/helper-get-function-arity": "7.0.0-beta.51",
+        "@babel/template": "7.0.0-beta.51",
+        "@babel/types": "7.0.0-beta.51"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.49.tgz",
-      "integrity": "sha1-z1Aj8y0q2S0Ic3STnOwJUby1FEE=",
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.51.tgz",
+      "integrity": "sha1-MoGy0EWvlcFyzpGyCCXYXqRnZBE=",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/types": "7.0.0-beta.51"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.49.tgz",
-      "integrity": "sha1-QNeO2glo0BGxxShm5XRs+yPldUg=",
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.51.tgz",
+      "integrity": "sha1-imw/ZsTSZTUvwHdIT59ugKUauXg=",
       "dev": true,
       "requires": {
-        "@babel/types": "7.0.0-beta.49"
+        "@babel/types": "7.0.0-beta.51"
       }
     },
     "@babel/highlight": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.49.tgz",
-      "integrity": "sha1-lr3GtD4TSCASumaRsQGEktOWIsw=",
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.51.tgz",
+      "integrity": "sha1-6IRK4loVlcz9QriWI7Q3bKBtIl0=",
       "dev": true,
       "requires": {
         "chalk": "^2.0.0",
@@ -75,35 +75,35 @@
       }
     },
     "@babel/parser": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.49.tgz",
-      "integrity": "sha1-lE0MW6KBK7FZ7b0iZ0Ov0mUXm9w=",
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.0.0-beta.51.tgz",
+      "integrity": "sha1-J87C30Cd9gr1gnDtj2qlVAnqhvY=",
       "dev": true
     },
     "@babel/template": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.49.tgz",
-      "integrity": "sha1-44q+ghfLl5P0YaUwbXrXRdg+HSc=",
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.51.tgz",
+      "integrity": "sha1-lgKkCuvPNXrpZ34lMu9fyBD1+/8=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.49",
-        "@babel/parser": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
+        "@babel/code-frame": "7.0.0-beta.51",
+        "@babel/parser": "7.0.0-beta.51",
+        "@babel/types": "7.0.0-beta.51",
         "lodash": "^4.17.5"
       }
     },
     "@babel/traverse": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.49.tgz",
-      "integrity": "sha1-TypzaCoYM07WYl0QCo0nMZ98LWg=",
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.51.tgz",
+      "integrity": "sha1-mB2vLOw0emIx06odnhgDsDqqpKg=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "7.0.0-beta.49",
-        "@babel/generator": "7.0.0-beta.49",
-        "@babel/helper-function-name": "7.0.0-beta.49",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.49",
-        "@babel/parser": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
+        "@babel/code-frame": "7.0.0-beta.51",
+        "@babel/generator": "7.0.0-beta.51",
+        "@babel/helper-function-name": "7.0.0-beta.51",
+        "@babel/helper-split-export-declaration": "7.0.0-beta.51",
+        "@babel/parser": "7.0.0-beta.51",
+        "@babel/types": "7.0.0-beta.51",
         "debug": "^3.1.0",
         "globals": "^11.1.0",
         "invariant": "^2.2.0",
@@ -111,9 +111,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.0.0-beta.49",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.49.tgz",
-      "integrity": "sha1-t+Oxw/TUz+Eb34yJ8e/V4WF7h6Y=",
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.51.tgz",
+      "integrity": "sha1-2AK3tUO1g2x3iqaReXq/APPZfqk=",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
@@ -122,9 +122,9 @@
       }
     },
     "@octokit/rest": {
-      "version": "15.9.2",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.9.2.tgz",
-      "integrity": "sha512-UpV9ZTI9ok73E0iFK+LH//c2/WIm6w/FGQ9LFF5GZFANsXut7z75LE0TCcgMZYdCS4eFm525qa3s+0INkPXigA==",
+      "version": "15.9.4",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.9.4.tgz",
+      "integrity": "sha512-v3CS1qW4IjriMvGgm4lDnYFBJlkwvzIbTxiipOcwVP8xeK8ih2pJofRhk7enmLngTtNEa+sIApJNkXxyyDKqLg==",
       "requires": {
         "before-after-hook": "^1.1.0",
         "btoa-lite": "^1.0.0",
@@ -176,24 +176,24 @@
       }
     },
     "@types/mocha": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.3.tgz",
-      "integrity": "sha512-C1wVVr7xhKu6c3Mb27dFzNYR05qvHwgtpN+JOYTGc1pKA7dCEDDYpscn7kul+bCUwa3NoGDbzI1pdznSOa397w==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.4.tgz",
+      "integrity": "sha512-XMHApnKWI0jvXU5gLcSTsRjJBpSzP0BG+2oGv98JFyS4a5R0tRy0oshHBRndb3BuHb9AwDKaUL8Ja7GfUvsG4g==",
       "dev": true
     },
     "@types/nock": {
-      "version": "9.1.3",
-      "resolved": "https://registry.npmjs.org/@types/nock/-/nock-9.1.3.tgz",
-      "integrity": "sha512-S8rJ+SaW82ICX87pZP62UcMifrMfjEdqNzSp+llx4YcvKw6bO650Ye6HwTqER1Dar3S40GIZECQisOrAICDCjA==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@types/nock/-/nock-9.3.0.tgz",
+      "integrity": "sha512-ZHf/X8rTQ5Tb1rHjxIJYqm55uO265agE3G7NoSXVa2ep+EcJXgB2fsme+zBvK7MhrxTwkC/xkB6THyv50u0MGw==",
       "dev": true,
       "requires": {
         "@types/node": "*"
       }
     },
     "@types/node": {
-      "version": "10.3.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.6.tgz",
-      "integrity": "sha512-h7VDRFL8IhdPw1JjiNVvhr+WynfKW09q2BOflIOA0yeuXNeXBP1bIRuBrysSryH4keaJ5bYUNp63aIyQL9YpDQ==",
+      "version": "10.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.5.1.tgz",
+      "integrity": "sha512-AFLl1IALIuyt6oK4AYZsgWVJ/5rnyzQWud7IebaZWWV3YmgtPZkQmYio9R5Ze/2pdd7XfqF5bP+hWS11mAKoOQ==",
       "dev": true
     },
     "@types/proxyquire": {
@@ -282,10 +282,9 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -308,15 +307,6 @@
       "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
       "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
       "dev": true
-    },
-    "argv-tools": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/argv-tools/-/argv-tools-0.1.1.tgz",
-      "integrity": "sha512-Cc0dBvx4dvrjjKpyDA6w8RlNAw8Su30NvZbWl/Tv9ZALEVlLVkWQiHMi84Q0xNfpVuSaiQbYkdmWK8g1PLGhKw==",
-      "requires": {
-        "array-back": "^2.0.0",
-        "find-replace": "^2.0.1"
-      }
     },
     "array-back": {
       "version": "2.0.0",
@@ -375,6 +365,15 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "dev": true
     },
+    "assert-rejects": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/assert-rejects/-/assert-rejects-0.1.1.tgz",
+      "integrity": "sha1-5HozNdiULHLj7NlGJh8OWKDaLvY=",
+      "dev": true,
+      "requires": {
+        "is-regexp": "^1.0.0"
+      }
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -425,6 +424,12 @@
         "js-tokens": "^3.0.2"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -474,9 +479,9 @@
       "dev": true
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -718,18 +723,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "command-line-args": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-5.0.2.tgz",
-      "integrity": "sha512-/qPcbL8zpqg53x4rAaqMFlRV4opN3pbla7I7k9x8kyOBMQoGT6WltjN6sXZuxOXw6DgdK7Ad+ijYS5gjcr7vlA==",
-      "requires": {
-        "argv-tools": "^0.1.1",
-        "array-back": "^2.0.0",
-        "find-replace": "^2.0.1",
-        "lodash.camelcase": "^4.3.0",
-        "typical": "^2.6.1"
-      }
-    },
     "command-line-usage": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-5.0.5.tgz",
@@ -742,9 +735,9 @@
       }
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
       "dev": true
     },
     "concat-map": {
@@ -793,14 +786,11 @@
       }
     },
     "cross-spawn": {
-      "version": "6.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-      "dev": true,
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "requires": {
-        "nice-try": "^1.0.4",
-        "path-key": "^2.0.1",
-        "semver": "^5.5.0",
+        "lru-cache": "^4.0.1",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
@@ -1277,15 +1267,28 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.1.tgz",
-          "integrity": "sha512-pgZos1vgOHDiC7gKNbZW8eKvCnNXARv2oqrGQT7Hzbq5Azp7aZG6DJzADnkuSq7RH6qkXp4J/m68yPX/2uBHyQ==",
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+          "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
             "fast-json-stable-stringify": "^2.0.0",
             "json-schema-traverse": "^0.4.1",
             "uri-js": "^4.2.1"
+          }
+        },
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
           }
         },
         "fast-deep-equal": {
@@ -1503,18 +1506,6 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
-      },
-      "dependencies": {
-        "cross-spawn": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "requires": {
-            "lru-cache": "^4.0.1",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        }
       }
     },
     "extend": {
@@ -1590,15 +1581,6 @@
       "requires": {
         "is-object": "~1.0.1",
         "merge-descriptors": "~1.0.0"
-      }
-    },
-    "find-replace": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-2.0.1.tgz",
-      "integrity": "sha512-LzDo3Fpa30FLIBsh6DCDnMN1KW2g4QKkqKmejlImgWY67dDFPX/x9Kh/op/GK522DchQXEvDi/wD48HKW49XOQ==",
-      "requires": {
-        "array-back": "^2.0.0",
-        "test-value": "^3.0.0"
       }
     },
     "find-up": {
@@ -1873,6 +1855,14 @@
       "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
       }
     },
     "has-flag": {
@@ -2162,6 +2152,12 @@
         "has": "^1.0.1"
       }
     },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "dev": true
+    },
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
@@ -2220,16 +2216,16 @@
       "dev": true
     },
     "istanbul-lib-instrument": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.2.1.tgz",
-      "integrity": "sha512-azWDq6BXKEZV1dGAnqCzBO5S+k3hX6IP63NHKXI9+sPNtaWEymJ6vh0rl65ZLgt8kbn7lmt63kdcOMXomW4B4Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-2.3.0.tgz",
+      "integrity": "sha512-Ie1LGWJVCFDDJKKH4g1ffpFcZTEXEd6ay5l9fE8539y4qPErJnzo4psnGzDH92tcKvdUDdbxrKySYIbt6zB9hw==",
       "dev": true,
       "requires": {
-        "@babel/generator": "7.0.0-beta.49",
-        "@babel/parser": "7.0.0-beta.49",
-        "@babel/template": "7.0.0-beta.49",
-        "@babel/traverse": "7.0.0-beta.49",
-        "@babel/types": "7.0.0-beta.49",
+        "@babel/generator": "7.0.0-beta.51",
+        "@babel/parser": "7.0.0-beta.51",
+        "@babel/template": "7.0.0-beta.51",
+        "@babel/traverse": "7.0.0-beta.51",
+        "@babel/types": "7.0.0-beta.51",
         "istanbul-lib-coverage": "^2.0.0",
         "semver": "^5.5.0"
       }
@@ -2396,11 +2392,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
-    "lodash.camelcase": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-    },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
@@ -2561,10 +2552,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -2582,6 +2572,14 @@
       "dev": true,
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        }
       }
     },
     "mocha": {
@@ -2601,6 +2599,14 @@
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "supports-color": "5.4.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+          "dev": true
+        }
       }
     },
     "module-not-found-error": {
@@ -2678,9 +2684,9 @@
       }
     },
     "nock": {
-      "version": "9.3.3",
-      "resolved": "https://registry.npmjs.org/nock/-/nock-9.3.3.tgz",
-      "integrity": "sha512-FBgnx25er2ly7KBr0Est5F0z5g+lnyr6a72vZI1KMi7nTL4ojU6XpFhlrfw6CXRdnT2FA5i8exHiT1uVNUM1qA==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.4.0.tgz",
+      "integrity": "sha512-uSBTclJ8Nmp/E3173s4KUHd5SAdxcuNjpwwWILhODBev67vftqt540kwYQBxR43z8//42ImFbSPrStgDAVxA4A==",
       "dev": true,
       "requires": {
         "chai": "^4.1.2",
@@ -5111,9 +5117,9 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
     "prettier": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.6.tgz",
-      "integrity": "sha512-p5eqCNiohWZN++7aJXUVj0JgLqHCPLf9GLIcLBHGNWs4Y9FJOPs6+KNO2WT0udJIQJTbeZFrJkjzjcb8fkAYYQ==",
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.13.7.tgz",
+      "integrity": "sha512-KIU72UmYPGk4MujZGYMFwinB7lOf2LsDNGSOC8ufevsrPLISrZbNJlWstRi3m0AMuszbH+EFSQ/r6w56RSPK6w==",
       "dev": true
     },
     "process-nextick-args": {
@@ -5187,13 +5193,6 @@
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        }
       }
     },
     "read-pkg": {
@@ -5604,13 +5603,6 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "requires": {
         "ansi-regex": "^3.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        }
       }
     },
     "strip-bom": {
@@ -5662,9 +5654,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.1.tgz",
-          "integrity": "sha512-pgZos1vgOHDiC7gKNbZW8eKvCnNXARv2oqrGQT7Hzbq5Azp7aZG6DJzADnkuSq7RH6qkXp4J/m68yPX/2uBHyQ==",
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
+          "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^2.0.1",
@@ -5711,15 +5703,6 @@
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "requires": {
         "execa": "^0.7.0"
-      }
-    },
-    "test-value": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/test-value/-/test-value-3.0.0.tgz",
-      "integrity": "sha512-sVACdAWcZkSU9x7AOmJo5TqE+GyNJknHaHsMrR6ZnhjVlVN9Yx6FjHrsKZ3BjIpPCT68zYesPWkakrNupwfOTQ==",
-      "requires": {
-        "array-back": "^2.0.0",
-        "typical": "^2.6.1"
       }
     },
     "text-encoding": {
@@ -5984,9 +5967,9 @@
       "dev": true
     },
     "uuid": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.0.tgz",
-      "integrity": "sha512-ijO9N2xY/YaOqQ5yz5c4sy2ZjWmA6AR6zASb/gdpeKZ8+948CxwfMW9RrKVk5may6ev8c0/Xguu32e2Llelpqw==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
       "dev": true
     },
     "validate-npm-package-license": {
@@ -6088,9 +6071,9 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs-parser": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.0.0.tgz",
-      "integrity": "sha512-+DHejWujTVYeMHLff8U96rLc4uE4Emncoftvn5AjhB1Jw1pWxLzgBUT/WYbPrHmy6YPEBTZQx5myHhVcuuu64g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
       "requires": {
         "camelcase": "^4.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "@octokit/rest": "^15.0.1",
     "axios": "^0.18.0",
-    "command-line-args": "^5.0.2",
     "command-line-usage": "^5.0.3",
     "extend": "^3.0.1",
     "js-yaml": "^3.10.0",
@@ -30,6 +29,7 @@
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^5.0.1",
     "@types/update-notifier": "^2.2.0",
+    "assert-rejects": "^0.1.1",
     "codecov": "^3.0.0",
     "eslint": "^5.0.0",
     "eslint-config-prettier": "^2.9.0",
@@ -52,12 +52,13 @@
     "lint": "eslint samples/*.js samples/*/*.js",
     "prettier": "prettier --write samples/*.js samples/*/*.js",
     "docs": "jsdoc -c .jsdoc.js",
-    "test": "nyc --reporter=lcov mocha --require intelli-espower-loader build/test && nyc report",
+    "test": "nyc mocha --require intelli-espower-loader build/test",
     "check": "gts check",
     "clean": "gts clean",
     "compile": "tsc -p .",
     "fix": "gts fix",
     "prepare": "npm run compile",
-    "pretest": "npm run compile"
+    "pretest": "npm run compile",
+    "posttest": "npm run check"
   }
 }

--- a/src/approve-prs.ts
+++ b/src/approve-prs.ts
@@ -24,6 +24,7 @@ import axios from 'axios';
 import {GitHub, GitHubRepository, PullRequest} from './lib/github';
 import {question} from './lib/question';
 import meow from 'meow';
+import {getConfig} from './lib/config';
 
 /**
  * Downloads and prints patch file (well, actually, any file) to a console.
@@ -133,9 +134,8 @@ export async function main(cli: meow.Result) {
     return;
   }
 
-  const github = new GitHub();
-  await github.init();
-
+  const config = await getConfig();
+  const github = new GitHub(config);
   const regex = new RegExp(cli.input[1] || '.*');
   const repos = await github.getRepositories();
   for (const repository of repos) {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -23,68 +23,37 @@ import * as util from 'util';
 const readFile = util.promisify(fs.readFile);
 import * as yaml from 'js-yaml';
 
-/**
- * Configuration object. Contains GitHub token, organization and repository
- * filter regex.
- */
-export class Config {
-  filename: string;
-  _config?: ConfigSettings;
+const cache = new Map<string, ConfigSettings>();
 
-  /**
-   * Constructs a configuration object.
-   * @constructor
-   * @param {string} configFilename Path to a configuration file. If not given,
-   * uses `./config.yaml`.
-   */
-  constructor(configFilename?: string) {
-    this.filename = configFilename || './config.yaml';
-    if (process.env.REPO_CONFIG_PATH) {
-      this.filename = process.env.REPO_CONFIG_PATH;
-    }
+export async function getConfig(configFilename?: string) {
+  let filename: string;
+  if (configFilename) {
+    filename = configFilename;
+  } else if (process.env.REPO_CONFIG_PATH) {
+    filename = process.env.REPO_CONFIG_PATH;
+  } else {
+    filename = './config.yaml';
   }
 
-  /**
-   * Reads the configuration.
-   */
-  async init() {
-    try {
-      const yamlContent = await readFile(this.filename);
-      this.config = yaml.load(yamlContent as {} as string) as ConfigSettings;
-    } catch (err) {
-      console.error(`Cannot read configuration file ${
-          this.filename}. Have you created it? Use config.yaml.default as a sample.`);
-      throw new Error('Configuration file is not found');
-    }
+  if (cache.has(filename)) {
+    return cache.get(filename)!;
   }
 
-  /**
-   * Get option value.
-   * @param {string} option Configuration option.
-   * @returns {string|Object} Requested value.
-   */
-  get(option: string) {
-    return this._config![option];
-  }
-
-  /**
-   * Get configuration object.
-   * @returns {Object} Parsed configuration yaml.
-   */
-  get config() {
-    return this._config;
-  }
-
-  /**
-   * Assigns configuration object.
-   * @param {Object} config Configuration object.
-   */
-  set config(config) {
-    this._config = config;
+  try {
+    const yamlContent = await readFile(filename, {encoding: 'utf8'});
+    const config = yaml.safeLoad(yamlContent) as ConfigSettings;
+    cache.set(filename, config);
+    return config;
+  } catch (err) {
+    console.error(`Cannot read configuration file ${
+        filename}. Have you created it? Use config.yaml.default as a sample.`);
+    throw new Error('Configuration file is not found');
   }
 }
 
 export interface ConfigSettings {
-  // tslint:disable-next-line no-any
-  [index: string]: any;
+  githubToken: string;
+  organization: string;
+  repoNameRegex: string;
+  circleciToken: string;
 }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -19,35 +19,22 @@
 'use strict';
 
 import OctoKit from '@octokit/rest';
-import {Config} from './config';
+import {ConfigSettings} from './config';
 
 /**
  * Wraps some octokit GitHub API calls.
  */
 export class GitHub {
-  organization?: string;
-  octokit?: OctoKit;
-  config?: Config;
+  protected organization?: string;
+  protected octokit?: OctoKit;
+  protected config: ConfigSettings;
 
-  constructor(options?: {}) {}
-
-  /**
-   * Reads configuration file and sets up GitHub authentication.
-   * @param {string} configFileName Path to configuration yaml file.
-   */
-  async init(configFilename?: string) {
-    const config = new Config(configFilename);
-    await config.init();
-
-    const octokit = new OctoKit();
-    octokit.authenticate({
-      type: 'token',
-      token: config.get('auth')['github-token'],
-    });
-
-    this.organization = config.get('organization') as string;
-    this.octokit = octokit;
+  constructor(config: ConfigSettings) {
     this.config = config;
+    const octokit = new OctoKit();
+    octokit.authenticate({type: 'token', token: config.githubToken});
+    this.organization = config.organization;
+    this.octokit = octokit;
   }
 
   /**
@@ -58,7 +45,7 @@ export class GitHub {
   async getRepositories() {
     const org = this.organization!;
     const type = 'public';
-    const repoNameRegexConfig = this.config!.get('repo-name-regex') as string;
+    const repoNameRegexConfig = this.config.repoNameRegex;
     const repoNameRegex = new RegExp(repoNameRegexConfig);
 
     const repos: GitHubRepository[] = [];

--- a/src/lib/update-file-in-branch.ts
+++ b/src/lib/update-file-in-branch.ts
@@ -20,6 +20,7 @@
 'use strict';
 
 import {GitHub, Repository, GitHubRepository} from './github';
+import {getConfig} from './config';
 
 /**
  * Updates and commits one existing file in the given branch of the given
@@ -97,36 +98,29 @@ export interface UpdateFileInBranchOptions {
  * @returns {undefined} No return value. Prints its progress to the console.
  */
 export async function updateFileInBranch(options: UpdateFileInBranchOptions) {
-  const path = options['path'];
-  if (path === undefined) {
-    console.error('updateFile: path is required');
-    return;
+  if (options.path === undefined) {
+    throw new Error('updateFile: path is required');
   }
 
-  const patchFunction = options['patchFunction'];
-  if (patchFunction === undefined) {
-    console.error('updateFile: path is required');
-    return;
+  if (options.patchFunction === undefined) {
+    throw new Error('updateFile: patchFunction is required');
   }
 
-  const branch = options['branch'];
-  if (branch === undefined) {
-    console.error('updateFile: branch is required');
-    return;
+  if (options.branch === undefined) {
+    throw new Error('updateFile: branch is required');
   }
 
-  const message = options['message'];
-  if (message === undefined) {
-    console.error('updateFile: message is required');
-    return;
+  if (options.message === undefined) {
+    throw new Error('updateFile: message is required');
   }
 
-  const github = new GitHub(options.config);
-  await github.init();
-
+  const config = await getConfig();
+  const github = new GitHub(config);
   const repos = await github.getRepositories();
   for (const repository of repos) {
     console.log(repository.name);
-    await processRepository(repository, branch, path, patchFunction, message);
+    await processRepository(
+        repository, options.branch, options.path, options.patchFunction,
+        options.message);
   }
 }

--- a/src/lib/update-file.ts
+++ b/src/lib/update-file.ts
@@ -20,6 +20,7 @@
 'use strict';
 
 import {GitHub, Repository, GitHubRepository} from './github';
+import {getConfig} from './config';
 
 /**
  * Updates one existing file in the repository and sends a pull request with
@@ -145,41 +146,33 @@ export interface UpdateFileOptions {
  * @returns {undefined} No return value. Prints its progress to the console.
  */
 export async function updateFile(options: UpdateFileOptions) {
-  const path = options['path'];
-  if (path === undefined) {
-    console.error('updateFile: path is required');
-    return;
+  if (options.path === undefined) {
+    throw new Error('updateFile: path is required');
   }
 
-  const patchFunction = options['patchFunction'];
-  if (patchFunction === undefined) {
-    console.error('updateFile: patchFunction is required');
-    return;
+  if (options.patchFunction === undefined) {
+    throw new Error('updateFile: patchFunction is required');
   }
 
-  const branch = options['branch'];
-  if (branch === undefined) {
-    console.error('updateFile: branch is required');
-    return;
+  if (options.branch === undefined) {
+    throw new Error('updateFile: branch is required');
   }
 
-  const message = options['message'];
-  if (message === undefined) {
-    console.error('updateFile: message is required');
-    return;
+  if (options.message === undefined) {
+    throw new Error('updateFile: message is required');
   }
 
-  const comment = options['comment'] || '';
-  const reviewers = options['reviewers'] || [];
+  const comment = options.comment || '';
+  const reviewers = options.reviewers || [];
 
-  const github = new GitHub(options.config);
-  await github.init();
-
+  const config = await getConfig();
+  const github = new GitHub(config);
   const repos = await github.getRepositories();
   for (const repository of repos) {
     console.log(repository.name);
     await processRepository(
-        repository, path, patchFunction, branch, message, comment, reviewers);
+        repository, options.path, options.patchFunction, options.branch,
+        options.message, comment, reviewers);
   }
 }
 

--- a/src/lib/update-repo.ts
+++ b/src/lib/update-repo.ts
@@ -28,6 +28,7 @@ const readFile = util.promisify(fs.readFile);
 const tmp = require('tmp-promise');
 
 import {GitHub, GitHubRepository} from './github';
+import {getConfig} from './config';
 
 /**
  * Updates files in the cloned repository and sends a pull request with
@@ -185,35 +186,29 @@ export interface UpdateRepoOptions {
  * @returns {undefined} No return value. Prints its progress to the console.
  */
 export async function updateRepo(options: UpdateRepoOptions) {
-  const updateCallback = options.updateCallback;
-  if (updateCallback === undefined) {
-    console.error('updateRepo: updateCallback is required');
-    return;
+  if (options.updateCallback === undefined) {
+    throw new Error('updateRepo: updateCallback is required');
   }
 
-  const branch = options.branch;
-  if (branch === undefined) {
-    console.error('updateRepo: branch is required');
-    return;
+  if (options.branch === undefined) {
+    throw new Error('updateRepo: branch is required');
   }
 
-  const message = options.message;
-  if (message === undefined) {
-    console.error('updateRepo: message is required');
-    return;
+  if (options.message === undefined) {
+    throw new Error('updateRepo: message is required');
   }
 
   const comment = options.comment || '';
   const reviewers = options.reviewers || [];
 
-  const github = new GitHub(options.config);
-  await github.init();
-
+  const config = await getConfig();
+  const github = new GitHub(config);
   const repos = await github.getRepositories();
   for (const repository of repos) {
     console.log(repository.name);
     await processRepository(
-        repository, updateCallback, branch, message, comment, reviewers);
+        repository, options.updateCallback, options.branch, options.message,
+        comment, reviewers);
   }
 }
 

--- a/src/reject-prs.ts
+++ b/src/reject-prs.ts
@@ -22,6 +22,7 @@
 
 import {GitHub, GitHubRepository, PullRequest} from './lib/github';
 import meow from 'meow';
+import {getConfig} from './lib/config';
 
 /**
  * Process one pull request: close it
@@ -53,10 +54,8 @@ export async function main(options: meow.Result) {
     console.log('Automatically reject all PRs that match a given filter.');
     return;
   }
-
-  const github = new GitHub();
-  await github.init();
-
+  const config = await getConfig();
+  const github = new GitHub(config);
   const regex = new RegExp(options.input[1]);
   const repos = await github.getRepositories();
   for (const repository of repos) {

--- a/src/repo-check.ts
+++ b/src/repo-check.ts
@@ -22,6 +22,7 @@
 import axios from 'axios';
 import {GitHub, GitHubRepository} from './lib/github';
 import {CircleCI} from './lib/circleci';
+import {getConfig} from './lib/config';
 
 /**
  * Logs and counts errors and warnings to console with fancy coloring.
@@ -277,12 +278,9 @@ async function checkReadmeLinks(logger: Logger, repository: GitHubRepository) {
  * @param {Logger} logger Logger object.
  */
 async function checkAllRepositories(logger: Logger) {
-  const github = new GitHub();
-  await github.init();
-
-  const circleci = new CircleCI();
-  await circleci.init();
-
+  const config = await getConfig();
+  const github = new GitHub(config);
+  const circleci = new CircleCI(config);
   const repos = await github.getRepositories();
   let index = 0;
   for (const repository of repos) {

--- a/test/config.ts
+++ b/test/config.ts
@@ -21,25 +21,21 @@
 import assert from 'assert';
 import fs from 'fs';
 import yaml from 'js-yaml';
-import {Config} from '../src/lib/config';
+import {getConfig} from '../src/lib/config';
 const tmp = require('tmp-promise');
 
 const configObject1 = {
-  auth: {
-    'github-token': 'test-github-token',
-    'circleci-token': 'test-circleci-token',
-  },
+  githubToken: 'test-github-token',
+  circleciToken: 'test-circleci-token',
   organization: 'test-organization',
-  'repo-name-regex': 'test-repo-name-regex',
+  repoNameRegex: 'test-repo-name-regex',
 };
 
 const configObject2 = {
-  auth: {
-    'github-token': 'test-github-token-2',
-    'circleci-token': 'test-circleci-token-2',
-  },
+  githubToken: 'test-github-token-2',
+  circleciToken: 'test-circleci-token-2',
   organization: 'test-organization-2',
-  'repo-name-regex': 'test-repo-name-regex-2',
+  repoNameRegex: 'test-repo-name-regex-2'
 };
 
 describe('Config', () => {
@@ -61,38 +57,32 @@ describe('Config', () => {
   });
 
   it('should read default configuration file', async () => {
-    const config = new Config();
-    await config.init();
-    assert.deepEqual(config.config, configObject1);
+    const config = await getConfig();
+    assert.deepEqual(config, configObject1);
   });
 
   it('should return individual values', async () => {
-    const config = new Config();
-    await config.init();
-    assert.equal(config.get('organization'), configObject1['organization']);
-    assert.equal(
-        config.get('repo-name-regex'), configObject1['repo-name-regex']);
-    assert.deepEqual(config.get('auth'), configObject1['auth']);
+    const config = await getConfig();
+    assert.equal(config.organization, configObject1.organization);
+    assert.equal(config.repoNameRegex, configObject1.repoNameRegex);
+    assert.equal(config.circleciToken, configObject1.circleciToken);
   });
 
   it('should accept configuration filename', async () => {
-    const config = new Config('./config2.yaml');
-    await config.init();
-    assert.deepEqual(config.config, configObject2);
+    const config = await getConfig('./config2.yaml');
+    assert.deepEqual(config, configObject2);
   });
 
   it('should read environment variable', async () => {
     process.env.REPO_CONFIG_PATH = './config2.yaml';
-    const config = new Config();
-    await config.init();
+    const config = await getConfig();
     delete process.env.REPO_CONFIG_PATH;
-    assert.deepEqual(config.config, configObject2);
+    assert.deepEqual(config, configObject2);
   });
 
   it('should fail if configuration file does not exist', done => {
     console.error = () => {};
-    const config = new Config('./config3.yaml');
-    config.init().catch(err => {
+    getConfig('./config3.yaml').catch(err => {
       assert(err instanceof Error);
       delete console.error;
       done();

--- a/test/fakes/fake-github.ts
+++ b/test/fakes/fake-github.ts
@@ -17,12 +17,13 @@
  */
 
 import crypto from 'crypto';
+import {ConfigSettings} from '../../src/lib/config';
 
 function hash(input: string) {
   return crypto.createHash('md5').update(input).digest('hex');
 }
 
-class FakeGitHubRepository {
+export class FakeGitHubRepository {
   // tslint:disable-next-line no-any
   branches: any;
   // tslint:disable-next-line no-any
@@ -150,18 +151,15 @@ class FakeGitHubRepository {
   }
 }
 
-const repository = new FakeGitHubRepository('test-repository');
+export const repository = new FakeGitHubRepository('test-repository');
 
-class FakeGitHub {
-  async init() {
-    return Promise.resolve();
+export class FakeGitHub {
+  protected config: ConfigSettings;
+  constructor(config: ConfigSettings) {
+    this.config = config;
   }
 
   async getRepositories() {
     return [repository];
   }
 }
-
-module.exports = FakeGitHub;
-module.exports.FakeGitHubRepository = FakeGitHubRepository;
-module.exports.repository = repository;

--- a/test/fakes/fake-tmp.ts
+++ b/test/fakes/fake-tmp.ts
@@ -18,21 +18,17 @@
 
 let dirName = '/tmp/fake-tmp-dir';
 
-function setDirName(dir: string) {
+export function setDirName(dir: string) {
   dirName = dir;
 }
 
-function getDirName() {
+export function getDirName() {
   return dirName;
 }
 
-async function dir() {
+export async function dir() {
   return new Promise(resolve => {
     const dir = getDirName();
     resolve({path: dir});
   });
 }
-
-module.exports.setDirName = setDirName;
-module.exports.getDirName = getDirName;
-module.exports.dir = dir;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
     "rootDir": ".",
-    "outDir": "build"
+    "outDir": "build",
+    "target": "es2016"
   },
   "include": [
     "src/*.ts",


### PR DESCRIPTION
So first off - I apologize for the size of this review. It started with a small fix (fixes #87), but the deeper I dug I started to find problems.  The unit tests in here were not doing what we wanted them to do. 

![you sit on a throne of lies](https://media2.giphy.com/media/xUySTNfFds1K3phXmo/giphy.gif)

Many of the tests used a `try`/`catch` pattern that was entirely ineffective.  Asserts inside of the try clause were triggering the catch, which happily ignored any errors.  I fixed this by swapping in the `assert-rejects` module, and being more careful about what we expected to have throw.  Many of the code changes in here are related to that test fix, and the broken stuff I found as a result. 

It's possible I'm way off here, so @alexander-fenster check my math bro. 

As far as intended / relevant changes
- Introduces static typing for the config objects
- Decouples creation of objects that require config (CircleCI, GitHub) from the process of acquiring the config.  
- Eliminates the `init` methods since config is now required in the constructor


I still have some manual testing and cleanup to do, but I wanted to get this in front of y'all. 