### PR TITLE
fix: repo apply CLI should not accept --execute/--command

### DIFF
--- a/src/apply-change.ts
+++ b/src/apply-change.ts
@@ -59,13 +59,6 @@ const commandLineOptions = [
     type: Boolean,
     description: 'No interactive questions - just make commits. Use carefully.',
   },
-  {
-    name: 'execute',
-    alias: 'e',
-    type: String,
-    defaultOption: true,
-    description: 'Command to execute inside the cloned repository folder.',
-  },
 ];
 
 const helpSections = [
@@ -136,10 +129,6 @@ function checkOptions(cli: meow.Result) {
   if (cli.flags.comment === undefined) {
     badOptions = true;
     console.error('Error: --comment is required.');
-  }
-  if (cli.flags.command === undefined) {
-    badOptions = true;
-    console.error('Error: command to execute is required.');
   }
   if (badOptions) {
     console.error(

--- a/src/apply-change.ts
+++ b/src/apply-change.ts
@@ -130,6 +130,10 @@ function checkOptions(cli: meow.Result) {
     badOptions = true;
     console.error('Error: --comment is required.');
   }
+  if (cli.input[1] === undefined) {
+    badOptions = true;
+    console.error('Error: command is required.');
+  }
   if (badOptions) {
     console.error(
         'Please run the script with --help to get some help on the command line options.');


### PR DESCRIPTION
Fails when I try to use the cli:

`$   repo approve [...flags] "echo hi!"`