### PR TITLE
fix: clone if dir does not exist

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -60,7 +60,7 @@ export async function sync() {
     const cloneUrl = repo.getRepository().ssh_url!;
     const cwd = path.join(rootPath, repo.name);
     return q.add(async () => {
-      if (dirs.indexOf(cwd) === -1) {
+      if (dirs.indexOf(cwd) !== -1) {
         await spawn('git reset --hard origin/master', {cwd});
         await spawn('git checkout master', {cwd});
         await spawn('git fetch origin', {cwd});


### PR DESCRIPTION
Because of this bug, it will try running commands from the non-existent directory, which will fail with `ENOENT`. I straced the process to understand what's going wrong :)

```
84007 chdir("/usr/local/google/home/fenster/.repo/gcp-metadata") = -1 ENOENT (No such file or directory)
```