### PR TITLE
fix: properly delete branch by git reference

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -202,11 +202,12 @@ export class GitHubRepository {
 
   /**
    * Deletes the given branch.
-   * @param {string} string Ref of the branch.
+   * @param {string} string Name of the branch.
    */
-  async deleteBranch(ref: string) {
+  async deleteBranch(branch: string) {
     const owner = this.repository.owner.login;
     const repo = this.repository.name;
+    const ref = `refs/heads/${branch}`;
     const result =
         await this.octokit.gitdata.deleteReference({owner, ref, repo});
     return result.data;

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -202,7 +202,7 @@ export class GitHubRepository {
 
   /**
    * Deletes the given branch.
-   * @param {string} string Name of the branch.
+   * @param {string} branch Name of the branch.
    */
   async deleteBranch(branch: string) {
     const owner = this.repository.owner.login;


### PR DESCRIPTION
Fixes #138. Branch deletion uses [Git References API](https://developer.github.com/v3/git/refs/#delete-a-reference) and requires a fully qualified reference e.g. `refs/heads/branch-name` to be passed, not just `branch-name`.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
