### PR TITLE
fix: actually delete branch

### DIFF
--- a/src/approve-prs.ts
+++ b/src/approve-prs.ts
@@ -125,7 +125,7 @@ async function processPullRequest(
         console.log('    branch deleted!');
       } catch (err) {
         console.warn(
-            `    error trying to delete branch ${htmlUrl}:`, err.toString());
+            `    error trying to delete branch ${ref}:`, err.toString());
         return;
       }
       break;

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -271,7 +271,7 @@ export class GitHubRepository {
   async deleteBranch(branch: string) {
     const owner = this.repository.owner.login;
     const repo = this.repository.name;
-    const ref = `refs/heads/${branch}`;
+    const ref = `heads/${branch}`;
     const result =
         await this.octokit.gitdata.deleteReference({owner, ref, repo});
     return result.data;


### PR DESCRIPTION
A little bit inconsistent API. No need to say `refs/` when we delete a branch.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
