### PR TITLE
fix: repo apply fails when untracked dirs were added

### DIFF
--- a/src/apply-change.ts
+++ b/src/apply-change.ts
@@ -104,7 +104,7 @@ const helpSections = [
  * @returns {string[]} List of filenames.
  */
 async function getFilesToCommit() {
-  const gitStatus = await exec('git status --porcelain');
+  const gitStatus = await exec('git status --porcelain --untracked-files');
   const lines = gitStatus.split('\n').filter((line: string) => line !== '');
   const files: string[] = [];
   for (const line of lines) {


### PR DESCRIPTION
Because `git status --porcelain` only list the new directories:

```
?? my_new_directory/
```

After adding `--untracked-files` option:

```
?? my_new_directory/new_file_A.txt
?? my_new_directory/new_file_B.txt
```