### PR TITLE
refactor: drop octokit, just use rest

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -3,7 +3,8 @@
   "exclude": [
     "src/*{/*,/**/*}.js",
     "src/*/v*/*.js",
-    "test/**/*.js"
+    "test/**/*.js",
+    "build/test"
   ],
   "watermarks": {
     "branches": [

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "@octokit/rest": "^16.0.0",
     "axios": "^0.18.0",
     "chalk": "^2.4.1",
     "command-line-usage": "^5.0.3",
@@ -61,14 +60,13 @@
     "typescript": "^3.0.0"
   },
   "scripts": {
-    "lint": "npm run check && eslint samples/*.js samples/*/*.js",
-    "prettier": "prettier --write samples/*.js samples/*/*.js",
+    "lint": "npm run check && eslint '**/*.js'",
     "docs": "echo no docs 👻",
-    "test": "nyc --reporter=lcov mocha build/test && nyc report",
+    "test": "nyc mocha build/test",
     "check": "gts check",
     "clean": "gts clean",
     "compile": "tsc -p .",
-    "fix": "gts fix",
+    "fix": "gts fix && eslint --fix '**/*.js'",
     "prepare": "npm run compile",
     "pretest": "npm run compile",
     "posttest": "npm run check",

--- a/src/apply-change.ts
+++ b/src/apply-change.ts
@@ -17,10 +17,7 @@
  * files that were added or changed.
  */
 
-'use strict';
-
 import * as childProcess from 'child_process';
-import * as pify from 'pify';
 const commandLineUsage = require('command-line-usage');
 import {updateRepo, UpdateRepoOptions} from './lib/update-repo';
 import {question} from './lib/question';

--- a/src/approve-prs.ts
+++ b/src/approve-prs.ts
@@ -12,10 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-'use strict';
+import * as meow from 'meow';
 
 import {GitHubRepository, PullRequest} from './lib/github';
-import * as meow from 'meow';
 import {process} from './lib/prIterator';
 
 async function processMethod(repository: GitHubRepository, pr: PullRequest) {
@@ -30,7 +29,6 @@ async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   }
   return true;
 }
-
 
 export async function approve(cli: meow.Result) {
   return process(cli, {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-'use strict';
 
 import {main as apply} from './apply-change';
 import {approve} from './approve-prs';

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -16,8 +16,6 @@
  * @fileoverview Configuration class.
  */
 
-'use strict';
-
 import * as fs from 'fs';
 import * as pify from 'pify';
 const readFile = pify(fs.readFile);

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-'use strict';
-
-import * as fs from 'fs';
 import chalk from 'chalk';
+import * as fs from 'fs';
 import {Writable} from 'stream';
 
 let stream: Writable;

--- a/src/lib/prIterator.ts
+++ b/src/lib/prIterator.ts
@@ -18,11 +18,10 @@
  * matching `regex`, one by one. Without a regex, will go through all open PRs.
  */
 
-'use strict';
-
-import {GitHub, GitHubRepository, PullRequest} from './github';
 import * as meow from 'meow';
+
 import {getConfig} from './config';
+import {GitHub, GitHubRepository, PullRequest} from './github';
 
 export interface PRIteratorOptions {
   commandName: string;

--- a/src/lib/update-file-in-branch.ts
+++ b/src/lib/update-file-in-branch.ts
@@ -17,10 +17,8 @@
  * in the given branch in many GitHub repositories.
  */
 
-'use strict';
-
-import {GitHub, GitHubRepository} from './github';
 import {getConfig} from './config';
+import {GitHub, GitHubRepository} from './github';
 
 /**
  * Updates and commits one existing file in the given branch of the given

--- a/src/lib/update-file.ts
+++ b/src/lib/update-file.ts
@@ -17,10 +17,8 @@
  * in many GitHub repositories, and sends pull requests with the change.
  */
 
-'use strict';
-
-import {GitHub, Repository, GitHubRepository} from './github';
 import {getConfig} from './config';
+import {GitHub, GitHubRepository} from './github';
 
 /**
  * Updates one existing file in the repository and sends a pull request with

--- a/src/lib/update-repo.ts
+++ b/src/lib/update-repo.ts
@@ -17,8 +17,6 @@
  * many GitHub repositories, and sends pull requests with the change.
  */
 
-'use strict';
-
 import * as child_process from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/src/merge-prs.ts
+++ b/src/merge-prs.ts
@@ -18,12 +18,10 @@
  * matching `regex`, one by one. Without a regex, will go through all open PRs.
  */
 
-'use strict';
+import * as meow from 'meow';
 
 import {GitHubRepository, PullRequest} from './lib/github';
-import * as meow from 'meow';
 import {process} from './lib/prIterator';
-
 
 async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   const title = pr.title;

--- a/src/reject-prs.ts
+++ b/src/reject-prs.ts
@@ -18,10 +18,9 @@
  * matching `regex`, one by one.
  */
 
-'use strict';
+import * as meow from 'meow';
 
 import {GitHubRepository, PullRequest} from './lib/github';
-import * as meow from 'meow';
 import {process} from './lib/prIterator';
 
 async function processMethod(repository: GitHubRepository, pr: PullRequest) {

--- a/src/repo-check.ts
+++ b/src/repo-check.ts
@@ -17,11 +17,10 @@
  * greenkeeper enabled, master branch protected, README links valid, etc.
  */
 
-'use strict';
-
 import axios from 'axios';
-import {GitHub, GitHubRepository} from './lib/github';
+
 import {getConfig} from './lib/config';
+import {GitHub, GitHubRepository} from './lib/github';
 
 /**
  * Logs and counts errors and warnings to console with fancy coloring.
@@ -77,7 +76,7 @@ async function checkGithubMasterBranchProtection(
         `${repository.name}: [!] cannot fetch branch information, no access?`);
     return;
   }
-  if (!getBranchRes['protected']) {
+  if (!getBranchRes.protected) {
     logger.error(`${
         repository.name}: [!] branch protection for master branch is disabled`);
     return;

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -17,18 +17,17 @@
  * files that were added or changed.
  */
 
-'use strict';
-
-import * as fs from 'fs';
-import * as path from 'path';
 import * as cp from 'child_process';
+import * as fs from 'fs';
 import * as meow from 'meow';
+import * as ora from 'ora';
+import * as Q from 'p-queue';
+import * as path from 'path';
+import * as pify from 'pify';
+
 import {getConfig} from './lib/config';
 import {GitHub} from './lib/github';
 import * as logger from './lib/logger';
-import * as Q from 'p-queue';
-import * as ora from 'ora';
-import * as pify from 'pify';
 
 const mkdir = pify(fs.mkdir);
 const readdir = pify(fs.readdir);

--- a/src/update-prs.ts
+++ b/src/update-prs.ts
@@ -18,10 +18,9 @@
  * matching `regex`, one by one. Without a regex, will go through all open PRs.
  */
 
-'use strict';
+import * as meow from 'meow';
 
 import {GitHubRepository, PullRequest} from './lib/github';
-import * as meow from 'meow';
 import {process} from './lib/prIterator';
 
 async function processMethod(repository: GitHubRepository, pr: PullRequest) {

--- a/system-test/.eslintrc.yml
+++ b/system-test/.eslintrc.yml
@@ -1,3 +1,0 @@
----
-rules:
-  no-console: off

--- a/system-test/system.ts
+++ b/system-test/system.ts
@@ -1,8 +1,15 @@
-/**
- * Copyright 2018 Google LLC
- *
- * Distributed under MIT license.
- * See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
- */
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 console.warn(`no system tests available 👎`);

--- a/test/.eslintrc.yml
+++ b/test/.eslintrc.yml
@@ -1,5 +1,0 @@
----
-env:
-  mocha: true
-rules:
-  node/no-unpublished-require: off

--- a/test/config.ts
+++ b/test/config.ts
@@ -16,14 +16,14 @@
  * @fileoverview Unit tests for lib/config.js.
  */
 
-'use strict';
-
 import * as assert from 'assert';
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 import * as os from 'os';
 import * as path from 'path';
-import {getConfig, Config} from '../src/lib/config';
+
+import {Config, getConfig} from '../src/lib/config';
+
 const tmp = require('tmp-promise');
 
 const clonePath = path.join(os.homedir(), '.repo');

--- a/test/github.ts
+++ b/test/github.ts
@@ -16,12 +16,12 @@
  * @fileoverview Unit tests for lib/github.js.
  */
 
-'use strict';
-
 import * as assert from 'assert';
-import * as proxyquire from 'proxyquire';
-import * as sinon from 'sinon';
+import * as nock from 'nock';
 import {Config} from '../src/lib/config';
+import {GitHub, GitHubRepository} from '../src/lib/github';
+
+nock.disableNetConnect();
 
 const testConfig: Config = {
   githubToken: 'test-github-token',
@@ -29,377 +29,33 @@ const testConfig: Config = {
   repos: [{org: 'test-organization', regex: 'matches'}]
 };
 
-class OctokitReposStub {
-  async getForOrg() {}
-  async getContent() {}
-  async getShaOfCommitRef() {}
-  async merge() {}
-  async createFile() {}
-  async updateFile() {}
-  async getBranch() {}
-  async getBranchProtection() {}
-  async getProtectedBranchRequiredStatusChecks() {}
-  async updateProtectedBranchRequiredStatusChecks() {}
-  async addCollaborator() {}
-}
-
-class OctokitPullRequestsStub {
-  async getAll() {}
-  async create() {}
-  async createReviewRequest() {}
-  async createReview() {}
-  async merge() {}
-  async update() {}
-}
-
-class OctokitGitdataStub {
-  async createReference() {}
-}
-
-class OctokitStub {
-  repos: OctokitReposStub;
-  pullRequests: OctokitPullRequestsStub;
-  gitdata: OctokitGitdataStub;
-  constructor() {
-    this.repos = new OctokitReposStub();
-    this.pullRequests = new OctokitPullRequestsStub();
-    this.gitdata = new OctokitGitdataStub();
-  }
-  authenticate() {}
-}
-
-// tslint:disable-next-line no-any
-function getPage(arr: any[], page: number, perPage: number) {
-  return arr.slice((page - 1) * perPage, page * perPage);
-}
-
-const {GitHub, GitHubRepository} = proxyquire('../src/lib/github', {
-  '@octokit/rest': OctokitStub,
-});
+const url = 'https://api.github.com';
+let repo: GitHubRepository;
 
 describe('GitHub', () => {
-  it('should authenticate octokit', async () => {
-    const spy = sinon.spy(OctokitStub.prototype, 'authenticate');
-    const expectedAuthParam = {
-      type: 'token',
-      token: testConfig.githubToken,
-    };
+  it('should get the list of repositories', async () => {
     const github = new GitHub(testConfig);
-    assert(spy.calledOnce);
-    assert(spy.calledWith(expectedAuthParam));
-  });
-
-  it('should get repositories', async () => {
-    if (testConfig.repos === undefined) {
-      throw new Error('no repos');
-    }
-    const repo = testConfig.repos[0];
-    if (repo === undefined) {
-      throw new Error('no repo');
-    }
-    const testOrg = repo.org;
-    const testType = 'public';
-    const repositories = [
-      {name: 'matches-1'},
-      {name: 'does-not-match-1'},
-      {name: '2-matches'},
-      {name: '2-does-not-match'},
-    ];
-    const github = new GitHub(testConfig);
-    const stub = sinon.stub(github.octokit.repos, 'getForOrg');
-    stub.callsFake(({org, type, page, per_page}) => {
-      assert.strictEqual(org, testOrg);
-      assert.strictEqual(type, testType);
-      return Promise.resolve({
-        data: getPage(repositories, page || 1, per_page || 1),
-      });
-    });
-
+    const path =
+        '/orgs/test-organization/repos?type=public&page=1&per_page=100';
+    const name = 'matches';
+    const owner = {login: 'test-organization'};
+    const scope = nock(url).get(path).reply(200, [{name, owner}]);
     const repos = await github.getRepositories();
-    assert.strictEqual(repos.length, 2);
-    assert.strictEqual(repos[0].name, 'matches-1');
-    assert.strictEqual(repos[0].organization, testOrg);
-    assert.strictEqual(repos[1].name, '2-matches');
-    assert.strictEqual(repos[1].organization, testOrg);
-    stub.restore();
-  });
-});
-
-describe('GitHubRepository', () => {
-  const owner = 'test-login';
-  const repo = 'test-repo';
-  const repositoryObject = {name: repo, owner: {login: owner}};
-  const octokit = new OctokitStub();
-  const organization = 'test-organization';
-  const repository =
-      new GitHubRepository(octokit, repositoryObject, organization);
-
-  it('should return repository object', done => {
-    assert.deepStrictEqual(repository.getRepository(), repositoryObject);
-    done();
+    scope.done();
+    assert.strictEqual(repos.length, 1);
+    repo = repos[0];
   });
 
-  it('should return repository name', done => {
-    assert.strictEqual(repository.name, repo);
-    done();
-  });
-
-  it('should get file', async () => {
-    const content = 'test-content';
-    const path = 'test-path';
-    const stub =
-        sinon.stub(octokit.repos, 'getContent').returns(Promise.resolve({
-          data: content,
-        }));
-    const result = await repository.getFile(path);
-    assert(stub.calledOnce);
-    assert(stub.calledWith({owner, repo, path}));
-    assert.strictEqual(result, content);
-    stub.restore();
-  });
-
-  it('should get file from branch', async () => {
-    const ref = 'test-branch';
-    const content = 'test-content';
-    const path = 'test-path';
-    const stub =
-        sinon.stub(octokit.repos, 'getContent').returns(Promise.resolve({
-          data: content,
-        }));
-    const result = await repository.getFileFromBranch(ref, path);
-    assert(stub.calledOnce);
-    assert(stub.calledWith({owner, repo, path, ref}));
-    assert.strictEqual(result, content);
-    stub.restore();
-  });
-
-  it('should list open pull requests', async () => {
-    const prs = [{id: 1}, {id: 2}];
-    const stub = sinon.stub(octokit.pullRequests, 'getAll');
-    const testOwner = owner;
-    const testRepo = repo;
-    const testState = 'open';
-    stub.callsFake(({owner, repo, state, page, per_page}) => {
-      assert.strictEqual(owner, testOwner);
-      assert.strictEqual(repo, testRepo);
-      assert.strictEqual(state, testState);
-      return Promise.resolve({data: getPage(prs, page || 1, per_page || 1)});
-    });
-    const result = await repository.listPullRequests();
-    assert.deepStrictEqual(result, prs);
-    stub.restore();
-  });
-
-  it('should list pull requests', async () => {
-    const prs = [{id: 1}, {id: 2}];
-    const stub = sinon.stub(octokit.pullRequests, 'getAll');
-    const testOwner = owner;
-    const testRepo = repo;
-    const testState = 'test-state';
-    stub.callsFake(({owner, repo, state, page, per_page}) => {
-      assert.strictEqual(owner, testOwner);
-      assert.strictEqual(repo, testRepo);
-      assert.strictEqual(state, testState);
-      return Promise.resolve({data: getPage(prs, page || 1, per_page || 1)});
-    });
-    const result = await repository.listPullRequests(testState);
-    assert.deepStrictEqual(result, prs);
-    stub.restore();
-  });
-
-  it('should get latest commit to master', async () => {
-    const commit = {sha: 'test-sha'};
-    const ref = 'heads/master';
-    const stub = sinon.stub(octokit.repos, 'getShaOfCommitRef')
-                     .returns(Promise.resolve({data: commit}));
-    const result = await repository.getLatestCommitToMaster();
-    assert(stub.calledOnceWith({owner, repo, ref}));
-    assert.deepStrictEqual(result, commit);
-    stub.restore();
-  });
-
-  it('should create branch', async () => {
-    const created = {ref: 'test-ref'};
-    const branch = 'test-ref';
-    const sha = 'test-sha';
-    const ref = `refs/heads/${branch}`;
-    const stub = sinon.stub(octokit.gitdata, 'createReference')
-                     .returns(Promise.resolve({data: created}));
-    const result = await repository.createBranch(branch, sha);
-    assert(stub.calledOnceWith({owner, repo, ref, sha}));
-    assert.deepStrictEqual(result, created);
-    stub.restore();
-  });
-
-  it('should update branch', async () => {
-    const base = 'test-base';
-    const head = 'test-head';
-    const commit = {sha: 'test-sha'};
-    const stub = sinon.stub(octokit.repos, 'merge').returns(Promise.resolve({
-      data: commit
-    }));
-    const result = await repository.updateBranch(base, head);
-    assert(stub.calledOnceWith({owner, repo, base, head}));
-    assert.deepStrictEqual(result, commit);
-    stub.restore();
-  });
-
-  it('should create file in branch', async () => {
-    const branch = 'test-branch';
-    const path = 'test-path';
-    const message = 'test-message';
-    const content = 'test-content';
-    const commit = {sha: 'test-sha'};
-    const stub = sinon.stub(octokit.repos, 'createFile')
-                     .returns(Promise.resolve({data: commit}));
-    const result =
-        await repository.createFileInBranch(branch, path, message, content);
-    assert(stub.calledOnceWith({owner, repo, path, message, content, branch}));
-    assert.deepStrictEqual(result, commit);
-    stub.restore();
-  });
-
-  it('should update file in branch', async () => {
-    const branch = 'test-branch';
-    const path = 'test-path';
-    const message = 'test-message';
-    const content = 'test-content';
-    const sha = 'test-sha';
-    const commit = {sha: 'test-updated-sha'};
-    const stub = sinon.stub(octokit.repos, 'updateFile')
-                     .returns(Promise.resolve({data: commit}));
-    const result = await repository.updateFileInBranch(
-        branch, path, message, content, sha);
-    assert(stub.calledOnceWith(
-        {owner, repo, path, message, content, sha, branch}));
-    assert.deepStrictEqual(result, commit);
-    stub.restore();
-  });
-
-  it('should create pull request', async () => {
-    const branch = 'test-branch';
-    const title = 'test-title';
-    const body = 'test-body';
-    const head = `refs/heads/${branch}`;
-    const base = 'refs/heads/master';
-    const pr = {id: 1};
-    const stub = sinon.stub(octokit.pullRequests, 'create')
-                     .returns(Promise.resolve({data: pr}));
-    const result = await repository.createPullRequest(branch, title, body);
-    assert(stub.calledOnceWith({owner, repo, head, base, title, body}));
-    assert.deepStrictEqual(result, pr);
-    stub.restore();
-  });
-
-  it('should request review', async () => {
-    const prNumber = 42;
-    const reviewers = ['user1', 'user2'];
-    const review = {id: 1};
-    const stub = sinon.stub(octokit.pullRequests, 'createReviewRequest')
-                     .returns(Promise.resolve({data: review}));
-    const result = await repository.requestReview(prNumber, reviewers);
-    assert(stub.calledOnceWith({owner, repo, number: prNumber, reviewers}));
-    assert.deepStrictEqual(result, review);
-    stub.restore();
-  });
-
-  it('should approve pull request', async () => {
-    const prNumber = 42;
-    const pr = {number: prNumber};
-    const event = 'APPROVE';
-    const review = {id: 1};
-    const stub = sinon.stub(octokit.pullRequests, 'createReview')
-                     .returns(Promise.resolve({data: review}));
-    const result = await repository.approvePullRequest(pr);
-    assert(stub.calledOnceWith({owner, repo, number: prNumber, event}));
-    assert.deepStrictEqual(result, review);
-    stub.restore();
-  });
-
-  it('should close pull request', async () => {
-    const prNumber = 42;
-    const pr = {number: prNumber};
-    const state = 'closed';
-    const stub = sinon.stub(octokit.pullRequests, 'update')
-                     .returns(Promise.resolve({data: pr}));
-    const result = await repository.closePullRequest(pr);
-    assert(stub.calledOnceWith({owner, repo, number: prNumber, state}));
-    assert.deepStrictEqual(result, pr);
-    stub.restore();
-  });
-
-  it('should merge pull request', async () => {
-    const prNumber = 42;
-    const pr = {number: prNumber};
-    const mergeMethod = 'squash';
-    const commit = {sha: 'test-sha'};
-    const stub = sinon.stub(octokit.pullRequests, 'merge')
-                     .returns(Promise.resolve({data: commit}));
-    const result = await repository.mergePullRequest(pr);
-    assert(stub.calledOnceWith(
-        {owner, repo, number: prNumber, merge_method: mergeMethod}));
-    assert.deepStrictEqual(result, commit);
-    stub.restore();
-  });
-
-  it('should return branch settings', async () => {
-    const branch = 'test-branch';
-    const response = {name: branch};
-    const stub = sinon.stub(octokit.repos, 'getBranch')
-                     .returns(Promise.resolve({data: response}));
-    const result = await repository.getBranch(branch);
-    assert(stub.calledOnceWith({owner, repo, branch}));
-    assert.deepStrictEqual(result, response);
-    stub.restore();
-  });
-
-  it('should return branch protection settings', async () => {
-    const branch = 'master';
-    const protection = {'required-status-checks': []};
-    const stub = sinon.stub(octokit.repos, 'getBranchProtection')
-                     .returns(Promise.resolve({data: protection}));
-    const result = await repository.getRequiredMasterBranchProtection();
-    assert(stub.calledOnceWith({owner, repo, branch}));
-    assert.deepStrictEqual(result, protection);
-    stub.restore();
-  });
-
-  it('should return branch protection status checks', async () => {
-    const branch = 'master';
-    const statusChecks = {contexts: ['check1', 'check2']};
-    const stub =
-        sinon.stub(octokit.repos, 'getProtectedBranchRequiredStatusChecks')
-            .returns(Promise.resolve({data: statusChecks}));
-    const result =
-        await repository.getRequiredMasterBranchProtectionStatusChecks();
-    assert(stub.calledOnceWith({owner, repo, branch}));
-    assert.deepStrictEqual(result, statusChecks);
-    stub.restore();
-  });
-
-  it('should update branch protection status checks', async () => {
-    const branch = 'master';
-    const contexts = ['check1', 'check2'];
-    const strict = true;
-    const updatedResponse = {contexts};
-    const stub =
-        sinon.stub(octokit.repos, 'updateProtectedBranchRequiredStatusChecks')
-            .returns(Promise.resolve({data: updatedResponse}));
-    const result =
-        await repository.updateRequiredMasterBranchProtectionStatusChecks(
-            contexts);
-    assert(stub.calledOnceWith({owner, repo, branch, strict, contexts}));
-    assert.deepStrictEqual(result, updatedResponse);
-    stub.restore();
-  });
-
-  it('should add collaborator', async () => {
-    const username = 'username';
-    const permission = 'permission';
-    const stub = sinon.stub(octokit.repos, 'addCollaborator')
-                     .returns(Promise.resolve({data: {}}));
-    await repository.addCollaborator(username, permission);
-    assert(stub.calledOnceWith({owner, repo, username, permission}));
-    stub.restore();
+  it('should include auth headers', async () => {
+    const response = {hello: 'world'};
+    const path = `/repos/test-organization/matches/contents/index.test`;
+    const scope = nock(url)
+                      .get(path, undefined, {
+                        reqheaders: {authorization: 'token test-github-token'}
+                      })
+                      .reply(200, response);
+    const file = await repo.getFile('index.test');
+    assert.deepStrictEqual(file, response);
+    scope.done();
   });
 });


### PR DESCRIPTION
`octokit` was more trouble than it was worth.  They kept making breaking changes, and really it doesn't do much of anything useful.  I had to got to the github API ref docs anyway, so I just switched things over to using the raw HTTP API.  Does a few other things:
- removes `.eslintrc` files we weren't using
- removes `use strict` which gets emitted by default to the compiled sources
- fixes a bad license header
