### PR TITLE
refactor: drop usage of pify

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "meow": "^5.0.0",
     "ora": "^3.0.0",
     "p-queue": "^5.0.0",
-    "pify": "^4.0.0",
     "tmp-promise": "^2.0.0",
     "update-notifier": "^3.0.0"
   },
@@ -34,7 +33,6 @@
     "@types/mocha": "^5.2.3",
     "@types/nock": "^10.0.0",
     "@types/node": "^10.3.6",
-    "@types/pify": "^3.0.2",
     "@types/proxyquire": "^1.3.28",
     "@types/sinon": "^7.0.0",
     "@types/update-notifier": "^2.2.0",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -17,8 +17,8 @@
  */
 
 import * as fs from 'fs';
-import * as pify from 'pify';
-const readFile = pify(fs.readFile);
+import {promisify} from 'util';
+const readFile = promisify(fs.readFile);
 import * as yaml from 'js-yaml';
 import * as path from 'path';
 import * as os from 'os';

--- a/src/lib/update-repo.ts
+++ b/src/lib/update-repo.ts
@@ -20,9 +20,9 @@
 import * as child_process from 'child_process';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as pify from 'pify';
-const exec = pify(child_process.exec);
-const readFile = pify(fs.readFile);
+import {promisify} from 'util';
+const exec = promisify(child_process.exec);
+const readFile = promisify(fs.readFile);
 const tmp = require('tmp-promise');
 
 import {GitHub, GitHubRepository} from './github';

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -23,16 +23,16 @@ import * as meow from 'meow';
 import ora from 'ora';
 import * as Q from 'p-queue';
 import * as path from 'path';
-import * as pify from 'pify';
+import {promisify} from 'util';
 
 import {getConfig} from './lib/config';
 import {GitHub} from './lib/github';
 import * as logger from './lib/logger';
 
-const mkdir = pify(fs.mkdir);
-const readdir = pify(fs.readdir);
-const stat = pify(fs.stat);
-const spawn = pify(cp.exec);
+const mkdir = promisify(fs.mkdir);
+const readdir = promisify(fs.readdir);
+const stat = promisify(fs.stat);
+const spawn = promisify(cp.exec);
 
 function print(res: {stdout: string; stderr: string}) {
   if (res.stdout) {


### PR DESCRIPTION
Now that Node.js 6 is EOL, we can rely on `util.promisify`.