### PR TITLE
feat: add the `rename` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,16 +81,16 @@ or all PRs with the word `test` in the title:
 $ repo reject [regex]
 ```
 
+Iterates over all open pull requests matching `regex`, and closes
+them. For example, close all PRs with the word `test` in the title:
+
+`$ repo reject test`
+
 ### repo rename
 
 ```sh
 $ repo rename 'title to match' 'new title'
 ```
-
-Iterates over all open pull requests matching `regex`, and closes
-them. For example, close all PRs with the word `test` in the title:
-
-`$ repo reject test`
 
 ### repo apply
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ or all PRs with the word `test` in the title:
 $ repo reject [regex]
 ```
 
+### repo rename
+
+```sh
+$ repo rename 'title to match' 'new title'
+```
+
 Iterates over all open pull requests matching `regex`, and closes
 them. For example, close all PRs with the word `test` in the title:
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ them. For example, close all PRs with the word `test` in the title:
 $ repo rename 'title to match' 'new title'
 ```
 
+Iterates over all open pull requests matching `regex`, and renames
+them.
+
 ### repo apply
 
 ```sh

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 
 import {main as apply} from './apply-change';
 import {approve} from './approve-prs';
+import {rename} from './rename-prs';
 import {reject} from './reject-prs';
 import {update} from './update-prs';
 import {merge} from './merge-prs';
@@ -24,6 +25,7 @@ const cli = meow(
     $ repo update /regex/
     $ repo merge /regex/
     $ repo reject /regex/
+    $ repo rename /regex/ 'new PR title'
     $ repo tag /regex/ label1 label2 ...
     $ repo apply --branch branch --message message --comment comment [--reviewers username[,username...]] [--silent] command
     $ repo check
@@ -67,6 +69,9 @@ let p: Promise<void>;
 switch (cli.input[0]) {
   case 'approve':
     p = approve(cli);
+    break;
+  case 'rename':
+    p = rename(cli);
     break;
   case 'reject':
     p = reject(cli);

--- a/src/lib/asyncPrIterator.ts
+++ b/src/lib/asyncPrIterator.ts
@@ -1,0 +1,134 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as meow from 'meow';
+import * as Q from 'p-queue';
+import ora from 'ora';
+
+import {getConfig} from './config';
+import {GitHub, GitHubRepository, PullRequest} from './github';
+
+export interface PRIteratorOptions {
+  commandName: string; // approve
+  commandNamePastTense: string; // approved
+  commandActive: string; // approving
+  commandDesc: string;
+  processMethod: (
+    repository: GitHubRepository,
+    pr: PullRequest,
+    cli: meow.Result
+  ) => Promise<boolean>;
+}
+
+/**
+ * Main function. Iterates all open pull request in the repositories of the
+ * given organization matching given filters. Organization, filters, and GitHub
+ * token should be given in the configuration file.
+ * @param {string[]} args Command line arguments.
+ */
+export async function process(cli: meow.Result, options: PRIteratorOptions) {
+  if (cli.input.length < 2 || !cli.input[1]) {
+    console.log(`Usage: repo ${options.commandName} [regex]`);
+    console.log(options.commandDesc);
+    return;
+  }
+
+  const config = await getConfig();
+  const github = new GitHub(config);
+  const regex = new RegExp(cli.input[1] || '.*');
+  const repos = await github.getRepositories();
+  const successful: string[] = [];
+  const failed: string[] = [];
+  let processed = 0;
+  let scanned = 0;
+  let prs = new Array<{repo: GitHubRepository; pr: PullRequest}>();
+
+  const orb1 = ora(
+    `[${scanned}/${repos.length}] Scanning repos for PRs`
+  ).start();
+
+  // Concurrently find all PRs in all relevant repositories
+  const q = new Q({concurrency: 15});
+  q.addAll(
+    repos.map(repo => {
+      return async () => {
+        try {
+          const localPRs = await repo.listPullRequests();
+          prs.push(
+            ...localPRs.map(pr => {
+              return {repo, pr};
+            })
+          );
+          scanned++;
+          orb1.text = `[${scanned}/${repos.length}] Scanning repos for PRs`;
+        } catch (err) {
+          failed.push('cannot list open pull requests:', err.toString());
+        }
+      };
+    })
+  );
+  await q.onIdle();
+
+  // Filter the list of PRs to ones who match the PR title
+  prs = prs.filter(prSet => prSet.pr.title.match(regex));
+  orb1.succeed(
+    `[${scanned}/${repos.length}] repositories scanned, ${
+      prs.length
+    } matching PRs found`
+  );
+
+  // Concurrently process each relevant PR
+  const orb2 = ora(
+    `[${processed}/${prs.length}] ${options.commandNamePastTense}`
+  ).start();
+  q.addAll(
+    prs.map(prSet => {
+      return async () => {
+        const title = prSet.pr.title!;
+        if (title.match(regex)) {
+          orb2.text = `[${processed}/${prs.length}] ${
+            options.commandActive
+          } PRs`;
+          const result = await options.processMethod(prSet.repo, prSet.pr, cli);
+          if (result) {
+            successful.push(prSet.pr.html_url);
+          } else {
+            failed.push(prSet.pr.html_url);
+          }
+          processed++;
+          orb2.text = `[${processed}/${prs.length}] ${
+            options.commandActive
+          } PRs`;
+        }
+      };
+    })
+  );
+  await q.onIdle();
+
+  orb2.succeed(
+    `[${processed}/${prs.length}] PRs ${options.commandNamePastTense}`
+  );
+
+  console.log(`Successfully processed: ${successful.length} pull request(s)`);
+  for (const pr of successful) {
+    console.log(`  ${pr}`);
+  }
+
+  if (failed.length > 0) {
+    console.log(`Unable to process: ${failed.length} pull requests(s)`);
+    for (const pr of failed) {
+      console.log(`  ${pr}`);
+    }
+  }
+}

--- a/src/lib/asyncPrIterator.ts
+++ b/src/lib/asyncPrIterator.ts
@@ -44,6 +44,9 @@ export async function process(cli: meow.Result, options: PRIteratorOptions) {
     return;
   }
 
+  const concurrency = cli.flags.concurrency
+    ? Number(cli.flags.concurrency)
+    : 15;
   const config = await getConfig();
   const github = new GitHub(config);
   const regex = new RegExp(cli.input[1] || '.*');
@@ -59,7 +62,7 @@ export async function process(cli: meow.Result, options: PRIteratorOptions) {
   ).start();
 
   // Concurrently find all PRs in all relevant repositories
-  const q = new Q({concurrency: 15});
+  const q = new Q({concurrency});
   q.addAll(
     repos.map(repo => {
       return async () => {

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -392,6 +392,20 @@ export class GitHubRepository {
   }
 
   /**
+   * Renames the given pull request.
+   * @param {Object} pr Pull request object, as returned by GitHib API.
+   * @param {string} title New title to give the PR
+   * @returns Review object, as returned by GitHub API.
+   */
+  async renamePullRequest(pr: PullRequest, title: string) {
+    const owner = this.repository.owner.login;
+    const repo = this.repository.name;
+    const url = `/repos/${owner}/${repo}/pulls/${pr.number}`;
+    const result = await this.client.patch(url, {title});
+    return result.data;
+  }
+
+  /**
    * Applies a set of labels to a given pull request.
    * @param {Object} pr Pull request object, as returned by GitHib API.
    * @param {Array<string>} labels Labels to apply to the PR

--- a/src/rename-prs.ts
+++ b/src/rename-prs.ts
@@ -17,22 +17,22 @@ import * as meow from 'meow';
 import {GitHubRepository, PullRequest} from './lib/github';
 import {process} from './lib/asyncPrIterator';
 
+let title: string;
+
 async function processMethod(repository: GitHubRepository, pr: PullRequest) {
-  try {
-    await repository.approvePullRequest(pr);
-  } catch (err) {
-    return false;
-  }
+  await repository.renamePullRequest(pr, title);
   return true;
 }
 
-export async function approve(cli: meow.Result) {
+export async function rename(cli: meow.Result) {
+  title = cli.input[2];
+  console.log(`title: ${title}`);
   return process(cli, {
-    commandName: 'approve',
-    commandNamePastTense: 'approved',
-    commandActive: 'approving',
+    commandName: 'rename',
+    commandNamePastTense: 'renamed',
+    commandActive: 'renaming',
     commandDesc:
-      'Will show all open PRs with title matching regex and approve them.',
+      'Will show all open PRs with title matching regex and rename them.',
     processMethod,
   });
 }


### PR DESCRIPTION
This adds the `repo rename` command, which allows easy renaming of PRs matching a given title.  It also introduces a new async PR iterator, which allows concurrency of other commands.