### PR TITLE
fix: set commit title when merging PR

### DIFF
--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -439,8 +439,12 @@ export class GitHubRepository {
   async mergePullRequest(pr: PullRequest) {
     const owner = this.repository.owner.login;
     const repo = this.repository.name;
+    const title = pr.title;
     const url = `/repos/${owner}/${repo}/pulls/${pr.number}/merge`;
-    const result = await this.client.put(url, {merge_method: 'squash'});
+    const result = await this.client.put(url, {
+      merge_method: 'squash',
+      commit_title: title,
+    });
     return result.data;
   }
 


### PR DESCRIPTION
This is about renaming the PR. Squash-merging the PR sets the commit title to something auto-generated (based on the title of the first commit). Let's explicitly set the commit title to the PR title. Should be safer and easier than doing `git commit --amend` and `git push --force`.

Note: tests will only pass after #308 is merged.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
