### PR TITLE
docs: update clonePath to use absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You need to make your own [`config.yaml`](https://github.com/googleapis/github-r
 $ cat /User/beckwith/.repo.yaml
 ---
 githubToken: your-github-token
-clonePath: ~/.repo # optional
+clonePath: /User/beckwith/.repo # optional
 repos:
   - org: googleapis
     regex: nodejs-.*


### PR DESCRIPTION
tilda expansion does not work here