### PR TITLE
feat: repo list, and pretty printing PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@ or all PRs with the word `test` in the title:
 
 `$ repo approve test`
 
+### repo list
+
+```sh
+$ repo list [regex]
+```
+
+Iterates over all open pull requests matching `regex` (all PRs if
+no regex is given) in all configured repositories, and prints them.
+
+`$ repo list 🚀`
+
+or all PRs with the word `test` in the title:
+
+`$ repo list test`
+
 ### repo reject
 
 ```sh

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,21 @@
 #!/usr/bin/env node
 
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 import {main as apply} from './apply-change';
+import {list} from './list-prs';
 import {approve} from './approve-prs';
 import {rename} from './rename-prs';
 import {reject} from './reject-prs';
@@ -20,7 +35,8 @@ const cli = meow(
 	Usage
 	  $ repo <command>
 
-	Examples
+  Examples
+    $ repo list /regex/
     $ repo approve /regex/
     $ repo update /regex/
     $ repo merge /regex/
@@ -67,6 +83,9 @@ if (cli.input.length < 1) {
 
 let p: Promise<void>;
 switch (cli.input[0]) {
+  case 'list':
+    p = list(cli);
+    break;
   case 'approve':
     p = approve(cli);
     break;

--- a/src/list-prs.ts
+++ b/src/list-prs.ts
@@ -1,0 +1,32 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as meow from 'meow';
+
+import {GitHubRepository, PullRequest} from './lib/github';
+import {process} from './lib/asyncPrIterator';
+
+async function processMethod(repository: GitHubRepository, pr: PullRequest) {
+  return true;
+}
+
+export async function list(cli: meow.Result) {
+  return process(cli, {
+    commandName: 'list',
+    commandNamePastTense: 'listed',
+    commandActive: 'listing', // :)
+    commandDesc: 'Will list all open PRs with title matching regex.',
+    processMethod,
+  });
+}


### PR DESCRIPTION
I found it strange that we can mass-approve, mass-merge, mass-reject PRs but can't just see _what_ PRs will be affected.  So, introducing `repo list regex`, which effectively does nothing, just lets the processing function list all the PRs it found.

Also, improved the results table to list not only the PR URLs, but also their titles. Looks like here:

![image](https://user-images.githubusercontent.com/4015807/71747322-3ae4e080-2e24-11ea-8e5a-e1c851501ac2.png)

Fun fact: did you know that we have an extra space in `[CHANGE ME] Re-generated <HERE> to pick up...`? :)