### PR TITLE
fix(deps): use meow v6.0.0 with its own types

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "command-line-usage": "^6.0.0",
     "extend": "^3.0.2",
     "js-yaml": "^3.13.1",
-    "meow": "^5.0.0",
+    "meow": "^6.0.0",
     "ora": "^4.0.2",
     "p-queue": "^6.0.2",
     "tmp-promise": "^2.0.1",
@@ -29,7 +29,6 @@
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.9",
     "@types/js-yaml": "^3.12.1",
-    "@types/meow": "^5.0.0",
     "@types/mocha": "^5.2.7",
     "@types/nock": "^10.0.3",
     "@types/node": "^12.0.7",

--- a/src/apply-change.ts
+++ b/src/apply-change.ts
@@ -22,6 +22,7 @@ const commandLineUsage = require('command-line-usage');
 import {updateRepo, UpdateRepoOptions} from './lib/update-repo';
 import {question} from './lib/question';
 import * as meow from 'meow';
+import {meowFlags} from './cli';
 
 // tslint:disable-next-line:no-any
 const exec = (command: string, options?: object): Promise<string> =>
@@ -119,7 +120,7 @@ async function getFilesToCommit() {
  * @param {Object} options Options object, as returned by meow.
  * @returns {Boolean} True if OK to continue, false otherwise.
  */
-function checkOptions(cli: meow.Result) {
+function checkOptions(cli: meow.Result<typeof meowFlags>) {
   if (cli.flags.help) {
     console.log(commandLineUsage(helpSections));
     return false;
@@ -163,7 +164,10 @@ function checkOptions(cli: meow.Result) {
  * @returns {Promise<string[]>} A promise resolving to a list of files to
  * commit.
  */
-async function updateCallback(cli: meow.Result, repoPath: string) {
+async function updateCallback(
+  cli: meow.Result<typeof meowFlags>,
+  repoPath: string
+) {
   const cwd = process.cwd();
   try {
     process.chdir(repoPath);
@@ -198,7 +202,7 @@ async function updateCallback(cli: meow.Result, repoPath: string) {
 /**
  * Main function.
  */
-export async function main(cli: meow.Result) {
+export async function main(cli: meow.Result<typeof meowFlags>) {
   if (!checkOptions(cli)) {
     return;
   }
@@ -209,7 +213,9 @@ export async function main(cli: meow.Result) {
     comment: cli.flags.comment,
   } as UpdateRepoOptions;
   if (cli.flags.reviewers !== undefined) {
-    updateRepoOptions.reviewers = cli.flags.reviewers.split(/\s*,\s*/);
+    updateRepoOptions.reviewers = (cli.flags.reviewers as string).split(
+      /\s*,\s*/
+    );
   }
   await updateRepo(updateRepoOptions);
 }

--- a/src/approve-prs.ts
+++ b/src/approve-prs.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as meow from 'meow';
+import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
 import {process} from './lib/asyncPrIterator';
@@ -26,7 +27,7 @@ async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   return true;
 }
 
-export async function approve(cli: meow.Result) {
+export async function approve(cli: meow.Result<typeof meowFlags>) {
   return process(cli, {
     commandName: 'approve',
     commandNamePastTense: 'approved',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,6 +30,36 @@ const pkg = require('../../package.json');
 
 updateNotifier({pkg}).notify();
 
+export const meowFlags: {
+  [key: string]: {type: 'string' | 'boolean'; alias?: string};
+} = {
+  branch: {
+    type: 'string',
+    alias: 'b',
+  },
+  message: {
+    type: 'string',
+    alias: 'm',
+  },
+  comment: {
+    type: 'string',
+    alias: 'c',
+  },
+  reviewers: {
+    type: 'string',
+    alias: 'r',
+  },
+  silent: {
+    type: 'boolean',
+    alias: 'q',
+  },
+  auto: {type: 'boolean'},
+  concurrency: {type: 'string'},
+};
+const meowOptions: meow.Options<typeof meowFlags> = {
+  flags: meowFlags,
+};
+
 const cli = meow(
   `
 	Usage
@@ -49,32 +79,7 @@ const cli = meow(
     $ repo exec -- git status
     $ repo exec --concurrency 10 -- git status
 `,
-  {
-    flags: {
-      branch: {
-        type: 'string',
-        alias: 'b',
-      },
-      message: {
-        type: 'string',
-        alias: 'm',
-      },
-      comment: {
-        type: 'string',
-        alias: 'c',
-      },
-      reviewers: {
-        type: 'string',
-        alias: 'r',
-      },
-      silent: {
-        type: 'boolean',
-        alias: 'q',
-      },
-      auto: {type: 'boolean'},
-      concurrency: {type: 'string'},
-    },
-  }
+  meowOptions
 );
 
 if (cli.input.length < 1) {

--- a/src/lib/asyncPrIterator.ts
+++ b/src/lib/asyncPrIterator.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as meow from 'meow';
+import {meowFlags} from '../cli';
 import Q from 'p-queue';
 import ora = require('ora');
 
@@ -27,7 +28,7 @@ export interface PRIteratorOptions {
   processMethod: (
     repository: GitHubRepository,
     pr: PullRequest,
-    cli: meow.Result
+    cli: meow.Result<typeof meowFlags>
   ) => Promise<boolean>;
 }
 
@@ -37,7 +38,10 @@ export interface PRIteratorOptions {
  * token should be given in the configuration file.
  * @param {string[]} args Command line arguments.
  */
-export async function process(cli: meow.Result, options: PRIteratorOptions) {
+export async function process(
+  cli: meow.Result<typeof meowFlags>,
+  options: PRIteratorOptions
+) {
   if (cli.input.length < 2 || !cli.input[1]) {
     console.log(`Usage: repo ${options.commandName} [regex]`);
     console.log(options.commandDesc);

--- a/src/list-prs.ts
+++ b/src/list-prs.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as meow from 'meow';
+import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
 import {process} from './lib/asyncPrIterator';
@@ -21,7 +22,7 @@ async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   return true;
 }
 
-export async function list(cli: meow.Result) {
+export async function list(cli: meow.Result<typeof meowFlags>) {
   return process(cli, {
     commandName: 'list',
     commandNamePastTense: 'listed',

--- a/src/merge-prs.ts
+++ b/src/merge-prs.ts
@@ -19,6 +19,7 @@
  */
 
 import * as meow from 'meow';
+import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
 import {process} from './lib/asyncPrIterator';
@@ -69,7 +70,7 @@ async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   return true;
 }
 
-export async function merge(cli: meow.Result) {
+export async function merge(cli: meow.Result<typeof meowFlags>) {
   return process(cli, {
     processMethod,
     commandActive: 'merging',

--- a/src/reject-prs.ts
+++ b/src/reject-prs.ts
@@ -19,6 +19,7 @@
  */
 
 import * as meow from 'meow';
+import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
 import {process} from './lib/asyncPrIterator';
@@ -33,7 +34,7 @@ async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   return true;
 }
 
-export async function reject(cli: meow.Result) {
+export async function reject(cli: meow.Result<typeof meowFlags>) {
   return process(cli, {
     commandName: 'reject',
     commandActive: 'rejecting',

--- a/src/rename-prs.ts
+++ b/src/rename-prs.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as meow from 'meow';
+import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
 import {process} from './lib/asyncPrIterator';
@@ -24,7 +25,7 @@ async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   return true;
 }
 
-export async function rename(cli: meow.Result) {
+export async function rename(cli: meow.Result<typeof meowFlags>) {
   title = cli.input[2];
   console.log(`title: ${title}`);
   return process(cli, {

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -20,6 +20,7 @@
 import * as cp from 'child_process';
 import * as fs from 'fs';
 import * as meow from 'meow';
+import {meowFlags} from './cli';
 import ora = require('ora');
 import Q from 'p-queue';
 import * as path from 'path';
@@ -48,7 +49,7 @@ function print(res: {stdout: string; stderr: string}) {
  * Clone all repositories into ~/.repo.
  * If repo already exists, fetch and reset.
  */
-export async function sync(cli: meow.Result) {
+export async function sync(cli: meow.Result<typeof meowFlags>) {
   const repos = await getRepos();
   const rootPath = await getRootPath();
   const dirs = await readdir(rootPath);
@@ -79,7 +80,7 @@ export async function sync(cli: meow.Result) {
   orb.succeed('Repo sync complete.');
 }
 
-export async function exec(cli: meow.Result) {
+export async function exec(cli: meow.Result<typeof meowFlags>) {
   const command = cli.input.slice(1);
   const rootPath = await getRootPath();
 

--- a/src/tag-prs.ts
+++ b/src/tag-prs.ts
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import * as meow from 'meow';
+import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
 import {process} from './lib/asyncPrIterator';
@@ -20,7 +21,7 @@ import {process} from './lib/asyncPrIterator';
 async function processMethod(
   repository: GitHubRepository,
   pr: PullRequest,
-  cli: meow.Result
+  cli: meow.Result<typeof meowFlags>
 ) {
   try {
     await repository.tagPullRequest(pr, cli.input.slice(2));
@@ -31,7 +32,7 @@ async function processMethod(
   return true;
 }
 
-export async function tag(cli: meow.Result) {
+export async function tag(cli: meow.Result<typeof meowFlags>) {
   return process(cli, {
     commandName: 'tag',
     commandActive: 'tagging',

--- a/src/update-prs.ts
+++ b/src/update-prs.ts
@@ -19,6 +19,7 @@
  */
 
 import * as meow from 'meow';
+import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
 import {process} from './lib/asyncPrIterator';
@@ -55,7 +56,7 @@ async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   return true;
 }
 
-export async function update(cli: meow.Result) {
+export async function update(cli: meow.Result<typeof meowFlags>) {
   return process(cli, {
     commandName: 'update',
     commandActive: 'updating',


### PR DESCRIPTION
`meow` v6.0.0 publishes its own types and, man, those types are weird. We are obviously the only people in this world who ever want to pass `meow.Result` to a function in a type-safe manner :)

We can forget about this forever and keep using `meow` v5, or can make this change.

Failed renovate PR for your reference: #338 