### PR TITLE
feat: implement --branch for repo commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,13 +66,13 @@ const cli = meow(
 	  $ repo <command>
 
   Examples
-    $ repo list /regex/
-    $ repo approve /regex/
-    $ repo update /regex/
-    $ repo merge /regex/
-    $ repo reject /regex/
-    $ repo rename /regex/ 'new PR title'
-    $ repo tag /regex/ label1 label2 ...
+    $ repo list [--branch branch] [regex]
+    $ repo approve [--branch branch] [regex]
+    $ repo update [--branch branch] [regex]
+    $ repo merge [--branch branch] [regex]
+    $ repo reject [--branch branch] [regex]
+    $ repo rename [--branch branch] regex 'new PR title'
+    $ repo tag [--branch branch] regex label1 label2 ...
     $ repo apply --branch branch --message message --comment comment [--reviewers username[,username...]] [--silent] command
     $ repo check
     $ repo sync

--- a/src/lib/asyncPrIterator.ts
+++ b/src/lib/asyncPrIterator.ts
@@ -42,8 +42,9 @@ export async function process(
   cli: meow.Result<typeof meowFlags>,
   options: PRIteratorOptions
 ) {
-  if (cli.input.length < 2 || !cli.input[1]) {
-    console.log(`Usage: repo ${options.commandName} [regex]`);
+  if (!cli.input[1] && !cli.flags.branch) {
+    console.log(`Usage: repo ${options.commandName} [--branch branch] [regex]`);
+    console.log(`Either branch name or regex must present.`);
     console.log(options.commandDesc);
     return;
   }
@@ -88,8 +89,11 @@ export async function process(
   );
   await q.onIdle();
 
-  // Filter the list of PRs to ones who match the PR title
+  // Filter the list of PRs to ones who match the PR title and/or the branch name
   prs = prs.filter(prSet => prSet.pr.title.match(regex));
+  if (cli.flags.branch) {
+    prs = prs.filter(prSet => prSet.pr.head.ref === cli.flags.branch);
+  }
   orb1.succeed(
     `[${scanned}/${repos.length}] repositories scanned, ${prs.length} matching PRs found`
   );


### PR DESCRIPTION
This PR makes it possible to do

```sh
$ repo list --branch autosynth
$ repo approve --branch autosynth
```
Branch and regex can be combined or used separately:
```sh
$ repo list CHANGE
$ repo list --branch autosynth CHANGE
```

Useful to track auto-PRs that were not merged. Here's what we have right now:

```sh
$ repo list --branch autosynth
Loaded 82 repositories from JSON config.
Total 82 unique repositories loaded.
✔ [82/82] repositories scanned, 21 matching PRs found
✔ [21/21] PRs listed
Successfully processed: 21 pull request(s)
  https://github.com/googleapis/gcs-resumable-upload/pull/301      chore: regenerate synth.metadata
  https://github.com/googleapis/node-gtoken/pull/264               chore: regenerate synth.metadata
  https://github.com/googleapis/cloud-profiler-nodejs/pull/584     chore: regenerate synth.metadata
  https://github.com/googleapis/gaxios/pull/225                    chore: regenerate synth.metadata
  https://github.com/googleapis/cloud-trace-nodejs/pull/1188       chore: regenerate synth.metadata
  https://github.com/googleapis/nodejs-automl/pull/316             docs: updates doc strings
  https://github.com/googleapis/nodejs-asset/pull/249              chore: regenerate synth.metadata
  https://github.com/googleapis/nodejs-bigtable/pull/604           build: migrate to new proto annotations
  https://github.com/googleapis/nodejs-datalabeling/pull/113       fix: load data_payloads proto earlier
  https://github.com/googleapis/nodejs-dataproc/pull/263           feat: add kerberos and autoscaling support
  https://github.com/googleapis/nodejs-compute/pull/395            chore: regenerate synth.metadata
  https://github.com/googleapis/nodejs-logging/pull/679            docs: update license headers
  https://github.com/googleapis/nodejs-paginator/pull/172          chore: regenerate synth.metadata
  https://github.com/googleapis/nodejs-phishing-protection/pull/78 chore: regenerate synth.metadata
  https://github.com/googleapis/nodejs-firestore-session/pull/90   chore: regenerate synth.metadata
  https://github.com/googleapis/nodejs-promisify/pull/163          chore: regenerate synth.metadata
  https://github.com/googleapis/nodejs-rcloadenv/pull/143          chore: regenerate synth.metadata
  https://github.com/googleapis/nodejs-resource/pull/275           chore: regenerate synth.metadata
  https://github.com/googleapis/nodejs-storage/pull/1050           build: generate synth.metadata
  https://github.com/googleapis/repo-automation-bots/pull/238      [CHANGE ME] Re-generated  to pick up changes in the API or client library generator.
  https://github.com/googleapis/teeny-request/pull/122             chore: regenerate synth.metadata
```