### PR TITLE
feat: add option for filtering by pr author

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -55,6 +55,7 @@ export const meowFlags: {
   },
   auto: {type: 'boolean'},
   concurrency: {type: 'string'},
+  author: {type: 'string'},
 };
 const meowOptions: meow.Options<typeof meowFlags> = {
   flags: meowFlags,
@@ -66,13 +67,13 @@ const cli = meow(
 	  $ repo <command>
 
   Examples
-    $ repo list [--branch branch] [regex]
-    $ repo approve [--branch branch] [regex]
-    $ repo update [--branch branch] [regex]
-    $ repo merge [--branch branch] [regex]
-    $ repo reject [--branch branch] [regex]
-    $ repo rename [--branch branch] regex 'new PR title'
-    $ repo tag [--branch branch] regex label1 label2 ...
+    $ repo list [--branch branch] [--author author] [regex]
+    $ repo approve [--branch branch] [--author author] [regex]
+    $ repo update [--branch branch] [--author author] [regex]
+    $ repo merge [--branch branch] [--author author] [regex]
+    $ repo reject [--branch branch] [--author author] [regex]
+    $ repo rename [--branch branch] [--author author] regex 'new PR title'
+    $ repo tag [--branch branch] [--author author] regex label1 label2 ...
     $ repo apply --branch branch --message message --comment comment [--reviewers username[,username...]] [--silent] command
     $ repo check
     $ repo sync

--- a/src/lib/asyncPrIterator.ts
+++ b/src/lib/asyncPrIterator.ts
@@ -94,6 +94,9 @@ export async function process(
   if (cli.flags.branch) {
     prs = prs.filter(prSet => prSet.pr.head.ref === cli.flags.branch);
   }
+  if (cli.flags.author) {
+    prs = prs.filter(prSet => prSet.pr.user.login === cli.flags.author);
+  }
   orb1.succeed(
     `[${scanned}/${repos.length}] repositories scanned, ${prs.length} matching PRs found`
   );


### PR DESCRIPTION
We may want to be extra sure when we're doing bulk actions that the PR is from the expected person and not a malicious user.

Adds an `--author=<github-username>` optional flag that will further filter PRs by `pull_request.user.login`.
