### PR TITLE
feat: adds support for performing mass operations on issues

### DIFF
--- a/src/approve-prs.ts
+++ b/src/approve-prs.ts
@@ -16,7 +16,7 @@ import * as meow from 'meow';
 import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
-import {process} from './lib/asyncPrIterator';
+import {process} from './lib/asyncItemIterator';
 
 async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   try {

--- a/src/approve-prs.ts
+++ b/src/approve-prs.ts
@@ -16,7 +16,7 @@ import * as meow from 'meow';
 import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
-import {process} from './lib/asyncItemIterator';
+import {processPRs} from './lib/asyncItemIterator';
 
 async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   try {
@@ -28,7 +28,7 @@ async function processMethod(repository: GitHubRepository, pr: PullRequest) {
 }
 
 export async function approve(cli: meow.Result<typeof meowFlags>) {
-  return process(cli, {
+  return processPRs(cli, {
     commandName: 'approve',
     commandNamePastTense: 'approved',
     commandActive: 'approving',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@
 
 import {main as apply} from './apply-change';
 import {list} from './list-prs';
+import {listIssues} from './list-issues';
 import {approve} from './approve-prs';
 import {rename} from './rename-prs';
 import {reject} from './reject-prs';
@@ -73,6 +74,7 @@ const cli = meow(
 
   Examples
     $ repo list [--branch branch] [--author author] [--title title]
+    $ repo list-issues [--branch branch] [--author author] [--title title] [--body body]
     $ repo approve [--branch branch] [--author author] [--title title]
     $ repo update [--branch branch] [--author author] [--title title]
     $ repo merge [--branch branch] [--author author] [--title title]
@@ -96,6 +98,9 @@ let p: Promise<void>;
 switch (cli.input[0]) {
   case 'list':
     p = list(cli);
+    break;
+  case 'list-issues':
+    p = listIssues(cli);
     break;
   case 'approve':
     p = approve(cli);

--- a/src/lib/asyncItemIterator.ts
+++ b/src/lib/asyncItemIterator.ts
@@ -23,7 +23,7 @@ import {GitHub, GitHubRepository, PullRequest, Issue} from './github';
 export interface PRIteratorOptions extends IteratorOptions {
   processMethod: (
     repository: GitHubRepository,
-    entity: PullRequest,
+    item: PullRequest,
     cli: meow.Result<typeof meowFlags>
   ) => Promise<boolean>;
 }
@@ -31,7 +31,7 @@ export interface PRIteratorOptions extends IteratorOptions {
 export interface IssueIteratorOptions extends IteratorOptions {
   processMethod: (
     repository: GitHubRepository,
-    entity: Issue,
+    item: Issue,
     cli: meow.Result<typeof meowFlags>
   ) => Promise<boolean>;
 }
@@ -133,7 +133,7 @@ export async function process(
   orb1.succeed(
     `[${scanned}/${repos.length}] repositories scanned, ${
       items.length
-    } matching ${processIssues ? 'issues' : 'PR'}s found`
+    } matching ${processIssues ? 'issue' : 'PR'}s found`
   );
 
   // Concurrently process each relevant PR or Issue
@@ -147,7 +147,7 @@ export async function process(
         if (title.match(regex)) {
           orb2.text = `[${processed}/${items.length}] ${
             options.commandActive
-          } ${processIssues ? 'issues' : 'PR'}s`;
+          } ${processIssues ? 'issue' : 'PR'}s`;
           let result;
           // By setting the process issues flag, the iterator can be made to
           // process a list of issues rather than PR:
@@ -174,7 +174,7 @@ export async function process(
           processed++;
           orb2.text = `[${processed}/${items.length}] ${
             options.commandActive
-          } ${processIssues ? 'issues' : 'PR'}s`;
+          } ${processIssues ? 'issue' : 'PR'}s`;
         }
       };
     })
@@ -182,7 +182,7 @@ export async function process(
   await q.onIdle();
 
   orb2.succeed(
-    `[${processed}/${items.length}] ${processIssues ? 'issues' : 'PR'}s ${
+    `[${processed}/${items.length}] ${processIssues ? 'issue' : 'PR'}s ${
       options.commandNamePastTense
     }`
   );
@@ -198,7 +198,7 @@ export async function process(
 
   console.log(
     `Successfully processed: ${successful.length} ${
-      processIssues ? 'issues' : 'PR'
+      processIssues ? 'issue' : 'PR'
     }s`
   );
   for (const item of successful) {
@@ -214,7 +214,7 @@ export async function process(
 
   if (error) {
     console.log(
-      `Error when processing ${processIssues ? 'issues' : 'PR'}s: ${error}`
+      `Error when processing ${processIssues ? 'issue' : 'PR'}s: ${error}`
     );
   }
 }
@@ -223,8 +223,7 @@ export async function process(
 // magic third parameter:
 export async function processIssues(
   cli: meow.Result<typeof meowFlags>,
-  options: PRIteratorOptions | IssueIteratorOptions,
-  processIssues = false
+  options: PRIteratorOptions | IssueIteratorOptions
 ) {
   return process(cli, options, true);
 }

--- a/src/lib/asyncItemIterator.ts
+++ b/src/lib/asyncItemIterator.ts
@@ -49,7 +49,7 @@ export interface IteratorOptions {
  * token should be given in the configuration file.
  * @param {string[]} args Command line arguments.
  */
-export async function process(
+async function process(
   cli: meow.Result<typeof meowFlags>,
   options: PRIteratorOptions | IssueIteratorOptions,
   processIssues = false
@@ -104,7 +104,9 @@ export async function process(
           scanned++;
           orb1.text = `[${scanned}/${repos.length}] Scanning repos for PRs`;
         } catch (err) {
-          error = `cannot list open pull requests: ${err.toString()}`;
+          error = `cannot list open ${
+            processIssues ? 'issue' : 'PR'
+          }s: ${err.toString()}`;
         }
       };
     })
@@ -153,14 +155,14 @@ export async function process(
           // process a list of issues rather than PR:
           if (processIssues) {
             const opts = options as IssueIteratorOptions;
-            const result = await opts.processMethod(
+            result = await opts.processMethod(
               itemSet.repo,
               itemSet.item as Issue,
               cli
             );
           } else {
             const opts = options as PRIteratorOptions;
-            const result = await opts.processMethod(
+            result = await opts.processMethod(
               itemSet.repo,
               itemSet.item as PullRequest,
               cli
@@ -206,7 +208,9 @@ export async function process(
   }
 
   if (failed.length > 0) {
-    console.log(`Unable to process: ${failed.length} pull requests(s)`);
+    console.log(
+      `Unable to process: ${failed.length} ${processIssues ? 'issue' : 'PR'}(s)`
+    );
     for (const item of failed) {
       console.log(`  ${item.html_url.padEnd(maxUrlLength, ' ')} ${item.title}`);
     }
@@ -219,8 +223,15 @@ export async function process(
   }
 }
 
-// Shorthand for processing list of issues rather than PRs, without setting the
-// magic third parameter:
+// Shorthand for processing list of PRs:
+export async function processPRs(
+  cli: meow.Result<typeof meowFlags>,
+  options: PRIteratorOptions | IssueIteratorOptions
+) {
+  return process(cli, options, false);
+}
+
+// Shorthand for processing list of issues:
 export async function processIssues(
   cli: meow.Result<typeof meowFlags>,
   options: PRIteratorOptions | IssueIteratorOptions

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -232,6 +232,28 @@ export class GitHubRepository {
   }
 
   /**
+   * List issues on a repository.
+   * @param {string} state Issue state (open, closed), defaults to open.
+   * @returns {Object[]} Issue objects, as returned by GitHub API.
+   */
+  async listIssues(state: 'open' | 'closed' | 'all' = 'open') {
+    const owner = this.repository.owner.login;
+    const repo = this.repository.name;
+    const prs: Issue[] = [];
+    const url = `/repos/${owner}/${repo}/issues`;
+    for (let page = 1; ; ++page) {
+      const result = await this.client.get<Issue[]>(url, {
+        params: {state, page},
+      });
+      if (result.data.length === 0) {
+        break;
+      }
+      prs.push(...result.data);
+    }
+    return prs;
+  }
+
+  /**
    * Returns latest commit to master branch of the GitHub repository.
    * @returns {Object} Commit object, as returned by GitHub API.
    */
@@ -521,14 +543,18 @@ export class GitHubRepository {
   }
 }
 
-export interface PullRequest {
-  number: number;
-  title: string;
-  html_url: string;
+export interface PullRequest extends Issue {
   patch_url: string;
-  user: User;
   base: {sha: string};
   head: {ref: string; label: string};
+}
+
+export interface Issue {
+  number: number;
+  title: string;
+  body: string;
+  html_url: string;
+  user: User;
 }
 
 export interface Repository {

--- a/src/list-issues.ts
+++ b/src/list-issues.ts
@@ -16,7 +16,7 @@ import * as meow from 'meow';
 import {meowFlags} from './cli';
 
 import {GitHubRepository, Issue} from './lib/github';
-import {processIssues} from './lib/asyncPrIterator';
+import {processIssues} from './lib/asyncItemIterator';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 async function processMethod(repository: GitHubRepository, issue: Issue) {
   return true;

--- a/src/list-issues.ts
+++ b/src/list-issues.ts
@@ -1,0 +1,33 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import * as meow from 'meow';
+import {meowFlags} from './cli';
+
+import {GitHubRepository, Issue} from './lib/github';
+import {processIssues} from './lib/asyncPrIterator';
+/* eslint-disable @typescript-eslint/no-unused-vars */
+async function processMethod(repository: GitHubRepository, issue: Issue) {
+  return true;
+}
+
+export async function listIssues(cli: meow.Result<typeof meowFlags>) {
+  return processIssues(cli, {
+    commandName: 'list-issues',
+    commandNamePastTense: 'listed',
+    commandActive: 'listing', // :)
+    commandDesc: 'Will list issues on a repository.',
+    processMethod,
+  });
+}

--- a/src/list-prs.ts
+++ b/src/list-prs.ts
@@ -16,14 +16,14 @@ import * as meow from 'meow';
 import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
-import {process} from './lib/asyncItemIterator';
+import {processPRs} from './lib/asyncItemIterator';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   return true;
 }
 
 export async function list(cli: meow.Result<typeof meowFlags>) {
-  return process(cli, {
+  return processPRs(cli, {
     commandName: 'list',
     commandNamePastTense: 'listed',
     commandActive: 'listing', // :)

--- a/src/list-prs.ts
+++ b/src/list-prs.ts
@@ -16,7 +16,7 @@ import * as meow from 'meow';
 import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
-import {process} from './lib/asyncPrIterator';
+import {process} from './lib/asyncItemIterator';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   return true;

--- a/src/merge-prs.ts
+++ b/src/merge-prs.ts
@@ -22,7 +22,7 @@ import * as meow from 'meow';
 import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
-import {process} from './lib/asyncItemIterator';
+import {processPRs} from './lib/asyncItemIterator';
 
 async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   const htmlUrl = pr.html_url;
@@ -71,7 +71,7 @@ async function processMethod(repository: GitHubRepository, pr: PullRequest) {
 }
 
 export async function merge(cli: meow.Result<typeof meowFlags>) {
-  return process(cli, {
+  return processPRs(cli, {
     processMethod,
     commandActive: 'merging',
     commandNamePastTense: 'merged',

--- a/src/merge-prs.ts
+++ b/src/merge-prs.ts
@@ -22,7 +22,7 @@ import * as meow from 'meow';
 import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
-import {process} from './lib/asyncPrIterator';
+import {process} from './lib/asyncItemIterator';
 
 async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   const htmlUrl = pr.html_url;

--- a/src/reject-prs.ts
+++ b/src/reject-prs.ts
@@ -22,7 +22,7 @@ import * as meow from 'meow';
 import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
-import {process} from './lib/asyncItemIterator';
+import {processPRs} from './lib/asyncItemIterator';
 
 async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   try {
@@ -35,7 +35,7 @@ async function processMethod(repository: GitHubRepository, pr: PullRequest) {
 }
 
 export async function reject(cli: meow.Result<typeof meowFlags>) {
-  return process(cli, {
+  return processPRs(cli, {
     commandName: 'reject',
     commandActive: 'rejecting',
     commandNamePastTense: 'rejected',

--- a/src/reject-prs.ts
+++ b/src/reject-prs.ts
@@ -22,7 +22,7 @@ import * as meow from 'meow';
 import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
-import {process} from './lib/asyncPrIterator';
+import {process} from './lib/asyncItemIterator';
 
 async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   try {

--- a/src/rename-prs.ts
+++ b/src/rename-prs.ts
@@ -16,7 +16,7 @@ import * as meow from 'meow';
 import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
-import {process} from './lib/asyncItemIterator';
+import {processPRs} from './lib/asyncItemIterator';
 
 let title: string;
 
@@ -32,7 +32,7 @@ export async function rename(cli: meow.Result<typeof meowFlags>) {
   }
   title = cli.input[1];
   console.log(`title: ${title}`);
-  return process(cli, {
+  return processPRs(cli, {
     commandName: 'rename',
     commandNamePastTense: 'renamed',
     commandActive: 'renaming',

--- a/src/rename-prs.ts
+++ b/src/rename-prs.ts
@@ -16,7 +16,7 @@ import * as meow from 'meow';
 import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
-import {process} from './lib/asyncPrIterator';
+import {process} from './lib/asyncItemIterator';
 
 let title: string;
 

--- a/src/tag-prs.ts
+++ b/src/tag-prs.ts
@@ -16,7 +16,7 @@ import * as meow from 'meow';
 import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
-import {process} from './lib/asyncPrIterator';
+import {process} from './lib/asyncItemIterator';
 
 async function processMethod(
   repository: GitHubRepository,

--- a/src/tag-prs.ts
+++ b/src/tag-prs.ts
@@ -16,7 +16,7 @@ import * as meow from 'meow';
 import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
-import {process} from './lib/asyncItemIterator';
+import {processPRs} from './lib/asyncItemIterator';
 
 async function processMethod(
   repository: GitHubRepository,
@@ -33,7 +33,7 @@ async function processMethod(
 }
 
 export async function tag(cli: meow.Result<typeof meowFlags>) {
-  return process(cli, {
+  return processPRs(cli, {
     commandName: 'tag',
     commandActive: 'tagging',
     commandNamePastTense: 'tagged',

--- a/src/update-prs.ts
+++ b/src/update-prs.ts
@@ -22,7 +22,7 @@ import * as meow from 'meow';
 import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
-import {process} from './lib/asyncItemIterator';
+import {processPRs} from './lib/asyncItemIterator';
 
 async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   const htmlUrl = pr.html_url;
@@ -57,7 +57,7 @@ async function processMethod(repository: GitHubRepository, pr: PullRequest) {
 }
 
 export async function update(cli: meow.Result<typeof meowFlags>) {
-  return process(cli, {
+  return processPRs(cli, {
     commandName: 'update',
     commandActive: 'updating',
     commandNamePastTense: 'updated',

--- a/src/update-prs.ts
+++ b/src/update-prs.ts
@@ -22,7 +22,7 @@ import * as meow from 'meow';
 import {meowFlags} from './cli';
 
 import {GitHubRepository, PullRequest} from './lib/github';
-import {process} from './lib/asyncPrIterator';
+import {process} from './lib/asyncItemIterator';
 
 async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   const htmlUrl = pr.html_url;


### PR DESCRIPTION
I wanted to be able to list any of our libraries that have an unclosed GA issue opened:

```
  https://github.com/googleapis/nodejs-billing/issues/3           GA Release of @google-cloud/billing
  https://github.com/googleapis/nodejs-dialogflow/issues/467      GA release
  https://github.com/googleapis/nodejs-document-ai/issues/11      promote library to GA
  https://github.com/googleapis/nodejs-media-translation/issues/3 promote library to GA
  https://github.com/googleapis/nodejs-memcache/issues/4          promote library to GA
  https://github.com/googleapis/nodejs-os-config/issues/2         promote library to GA
  https://github.com/googleapis/nodejs-recommender/issues/10      promoting library to GA
  https://github.com/googleapis/nodejs-service-directory/issues/4 Promote library to GA
```

This could be used to perform other mass operations on issues (I think someone asked for this in our weekly meeting today).