### PR TITLE
fix: allow regex search for branch listing

### DIFF
--- a/src/lib/asyncItemIterator.ts
+++ b/src/lib/asyncItemIterator.ts
@@ -115,11 +115,11 @@ async function process(
 
   // Filter the list of PRs or Issues to ones who match the PR title and/or the branch name
   items = items.filter(itemSet => itemSet.item.title.match(regex));
-  if (cli.flags.branch && processIssues) {
+  if (cli.flags.branch) {
     console.log(`Branch scan: ${cli.flags.branch}`);
     items = items.filter(itemSet => {
       const pr = itemSet.item as PullRequest;
-      return pr.head.ref === cli.flags.branch;
+      return new RegExp(cli.flags.branch as string).test(pr.head.ref);
     });
   }
   if (cli.flags.body) {

--- a/src/list-prs.ts
+++ b/src/list-prs.ts
@@ -14,13 +14,7 @@
 
 import * as meow from 'meow';
 import {meowFlags} from './cli';
-
-import {GitHubRepository, PullRequest} from './lib/github';
 import {processPRs} from './lib/asyncItemIterator';
-/* eslint-disable @typescript-eslint/no-unused-vars */
-async function processMethod(repository: GitHubRepository, pr: PullRequest) {
-  return true;
-}
 
 export async function list(cli: meow.Result<typeof meowFlags>) {
   return processPRs(cli, {
@@ -28,6 +22,6 @@ export async function list(cli: meow.Result<typeof meowFlags>) {
     commandNamePastTense: 'listed',
     commandActive: 'listing', // :)
     commandDesc: 'Will list all open PRs with title matching regex.',
-    processMethod,
+    processMethod: async () => true,
   });
 }


### PR DESCRIPTION
I wanted to do a `repo list --branch autosynth`, and have it list all PRs that fuzzy match `autosynth-self` or `autosynth-synthtool`.  I don't know why `--branch` was limited to issue searches, or why it didn't use a regex, but 🤷 