### PR TITLE
feat: add support for non-master default branches

### DIFF
--- a/config.yaml.default
+++ b/config.yaml.default
@@ -19,6 +19,12 @@ githubToken: your-github-token
 # https://help.github.com/en/github/searching-for-information-on-github/searching-for-repositories
 repoSearch: org:googleapis language:typescript language:javascript is:public archived:false
 
+# By default this toolkit will open a pull request with default branch as the base. If you want to
+# change this behavior you can uncomment the line below. This override will only apply to repositories
+# found through repoSearch (repositories found through the repos list below have their own individual
+# override configuration).
+# baseBranchOverride: main
+
 # Alternatively, you can specify repositories explicitly like this:
 # repos:
 #   - org: googleapis
@@ -27,3 +33,4 @@ repoSearch: org:googleapis language:typescript language:javascript is:public arc
 #     name: github-repo-automation
 #   - org: GoogleCloudPlatform
 #     regex: ^cloud-[a-z]*-nodejs$
+#     baseBranchOverride: master

--- a/config.yaml.default
+++ b/config.yaml.default
@@ -1,3 +1,4 @@
+  
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,12 +20,6 @@ githubToken: your-github-token
 # https://help.github.com/en/github/searching-for-information-on-github/searching-for-repositories
 repoSearch: org:googleapis language:typescript language:javascript is:public archived:false
 
-# By default this toolkit will open a pull request with default branch as the base. If you want to
-# change this behavior you can uncomment the line below. This override will only apply to repositories
-# found through repoSearch (repositories found through the repos list below have their own individual
-# override configuration).
-# baseBranchOverride: main
-
 # Alternatively, you can specify repositories explicitly like this:
 # repos:
 #   - org: googleapis
@@ -33,4 +28,3 @@ repoSearch: org:googleapis language:typescript language:javascript is:public arc
 #     name: github-repo-automation
 #   - org: GoogleCloudPlatform
 #     regex: ^cloud-[a-z]*-nodejs$
-#     baseBranchOverride: master

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -61,7 +61,9 @@ export interface Config {
       org: string;
       regex?: string;
       name?: string;
+      baseBranchOverride?: string;
     }
   ];
   repoSearch?: string;
+  baseBranchOverride?: string;
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -61,9 +61,7 @@ export interface Config {
       org: string;
       regex?: string;
       name?: string;
-      baseBranchOverride?: string;
     }
   ];
   repoSearch?: string;
-  baseBranchOverride?: string;
 }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -134,7 +134,14 @@ export class GitHub {
         ssh_url: `git@github.com:${org}/${name}.git`,
         default_branch: repo.branch,
       };
-      repos.push(new GitHubRepository(this.client, repository, org));
+      repos.push(
+        new GitHubRepository(
+          this.client,
+          repository,
+          org,
+          this.config.baseBranchOverride
+        )
+      );
     }
     return repos;
   }
@@ -434,15 +441,15 @@ export class GitHubRepository {
   async createPullRequest(branch: string, title: string, body: string) {
     const owner = this.repository.owner.login;
     const repo = this.repository.name;
-    const headRef = `refs/heads/${branch}`;
-    const baseRef = `refs/heads/${this.baseBranch}`;
+    const head = branch;
+    const base = this.baseBranch;
     const url = `/repos/${owner}/${repo}/pulls`;
     const result = await this.client.request({
       url,
       method: 'POST',
       data: {
-        headRef,
-        baseRef,
+        head,
+        base,
         title,
         body,
       },

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -62,7 +62,7 @@ export class GitHub {
             this.client,
             res.data,
             org,
-            this.config.baseBranchOverride
+            repo.baseBranchOverride
           )
         );
       } else if (repo.regex) {
@@ -72,14 +72,14 @@ export class GitHub {
             url: `/orgs/${org}/repos`,
             params: {type, page, per_page: 100},
           });
-          for (const repo of result.data) {
-            if (repo.name.match(repoNameRegex)) {
+          for (const restRepo of result.data) {
+            if (restRepo.name.match(repoNameRegex)) {
               repos.push(
                 new GitHubRepository(
                   this.client,
-                  repo,
+                  restRepo,
                   org,
-                  this.config.baseBranchOverride
+                  repo.baseBranchOverride
                 )
               );
             }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -57,14 +57,7 @@ export class GitHub {
         const res = await this.client.request<Repository>({
           url: `/repos/${org}/${repo.name}`,
         });
-        repos.push(
-          new GitHubRepository(
-            this.client,
-            res.data,
-            org,
-            repo.baseBranchOverride
-          )
-        );
+        repos.push(new GitHubRepository(this.client, res.data, org));
       } else if (repo.regex) {
         const repoNameRegex = new RegExp(repo.regex);
         for (let page = 1; ; ++page) {
@@ -74,14 +67,7 @@ export class GitHub {
           });
           for (const restRepo of result.data) {
             if (restRepo.name.match(repoNameRegex)) {
-              repos.push(
-                new GitHubRepository(
-                  this.client,
-                  restRepo,
-                  org,
-                  repo.baseBranchOverride
-                )
-              );
+              repos.push(new GitHubRepository(this.client, restRepo, org));
             }
           }
           if (result.data.length < 100) {
@@ -134,14 +120,7 @@ export class GitHub {
         ssh_url: `git@github.com:${org}/${name}.git`,
         default_branch: repo.branch,
       };
-      repos.push(
-        new GitHubRepository(
-          this.client,
-          repository,
-          org,
-          this.config.baseBranchOverride
-        )
-      );
+      repos.push(new GitHubRepository(this.client, repository, org));
     }
     return repos;
   }
@@ -198,18 +177,12 @@ export class GitHubRepository {
    * @param {Object} octokit OctoKit instance.
    * @param {Object} repository Repository object, as returned by GitHub API.
    * @param {string} organization Name of GitHub organization.
-   * @param {string} [baseBranchOverride] The base branch a PR should be made against, the default branch will be used if falsey.
    */
-  constructor(
-    client: Gaxios,
-    repository: Repository,
-    organization: string,
-    baseBranchOverride?: string
-  ) {
+  constructor(client: Gaxios, repository: Repository, organization: string) {
     this.client = client;
     this.repository = repository;
     this.organization = organization;
-    this.baseBranch = baseBranchOverride || this.repository.default_branch;
+    this.baseBranch = this.repository.default_branch;
   }
 
   /**

--- a/src/lib/update-file.ts
+++ b/src/lib/update-file.ts
@@ -31,7 +31,7 @@ import {GitHub, GitHubRepository} from './github';
  * @param {string} message Commit message and pull request title.
  * @param {string} comment Pull request body.
  * @param {string[]} reviewers Reviewers' GitHub logins for the pull request.
- * @returns {undefined} No return value. Prints its progress to the console.
+a * @returns {undefined} No return value. Prints its progress to the console.
  */
 async function processRepository(
   repository: GitHubRepository,
@@ -70,7 +70,7 @@ async function processRepository(
 
   let latestCommit: {[index: string]: string};
   try {
-    latestCommit = await repository.getLatestCommitToMaster();
+    latestCommit = await repository.getLatestCommitToBaseBranch();
   } catch (err) {
     console.warn(
       '  cannot get sha of latest commit, skipping this repository:',
@@ -111,7 +111,7 @@ async function processRepository(
     pullRequest = await repository.createPullRequest(branch, message, comment);
   } catch (err) {
     console.warn(
-      `  cannot create pull request for branch ${branch}! Branch is still there.`,
+      `  cannot create pull request for branch ${branch} -> base ${repository.baseBranch}! Branch is still there.`,
       err.toString()
     );
     return;

--- a/src/lib/update-file.ts
+++ b/src/lib/update-file.ts
@@ -31,7 +31,7 @@ import {GitHub, GitHubRepository} from './github';
  * @param {string} message Commit message and pull request title.
  * @param {string} comment Pull request body.
  * @param {string[]} reviewers Reviewers' GitHub logins for the pull request.
-a * @returns {undefined} No return value. Prints its progress to the console.
+ * @returns {undefined} No return value. Prints its progress to the console.
  */
 async function processRepository(
   repository: GitHubRepository,

--- a/src/lib/update-repo.ts
+++ b/src/lib/update-repo.ts
@@ -81,7 +81,7 @@ async function processRepository(
 
   let latestCommit: {[index: string]: string};
   try {
-    latestCommit = await repository.getLatestCommitToMaster();
+    latestCommit = await repository.getLatestCommitToBaseBranch();
   } catch (err) {
     console.warn(
       '  cannot get sha of latest commit, skipping this repository:',

--- a/src/merge-prs.ts
+++ b/src/merge-prs.ts
@@ -30,10 +30,10 @@ async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   const ref = pr.head.ref;
   let latestCommit: {[index: string]: string};
   try {
-    latestCommit = await repository.getLatestCommitToMaster();
+    latestCommit = await repository.getLatestCommitToBaseBranch();
   } catch (err) {
     console.warn(
-      '    cannot get sha of latest commit to master, skipping:',
+      '    cannot get sha of latest commit to the base branch, skipping:',
       err.toString()
     );
     return false;
@@ -41,7 +41,7 @@ async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   const latestMasterSha = latestCommit['sha'];
   if (latestMasterSha !== baseSha) {
     try {
-      await repository.updateBranch(ref, 'master');
+      await repository.updateBranch(ref, repository.baseBranch);
       console.log(
         'You might not be able to merge immediately because CI tasks will take some time.'
       );

--- a/src/repo-check.ts
+++ b/src/repo-check.ts
@@ -170,7 +170,7 @@ async function checkSamplesPackageDependency(
   let response;
   try {
     response = await request({
-      url: `https://raw.githubusercontent.com/${repository.organization}/${repository.name}/${repository.repository.default_branch}/package.json`,
+      url: `https://raw.githubusercontent.com/${repository.organization}/${repository.name}/${repository.baseBranch}/package.json`,
     });
   } catch (err) {
     logger.error(
@@ -182,7 +182,7 @@ async function checkSamplesPackageDependency(
   const packageJson: any = response.data;
   try {
     response = await request({
-      url: `https://raw.githubusercontent.com/${repository.organization}/${repository.name}/${repository.repository.default_branch}/samples/package.json`,
+      url: `https://raw.githubusercontent.com/${repository.organization}/${repository.name}/${repository.baseBranch}/samples/package.json`,
     });
   } catch (err) {
     logger.warning(`${repository.name}: [!] no samples/package.json.`);
@@ -219,7 +219,7 @@ async function checkReadmeLinks(logger: Logger, repository: GitHubRepository) {
   let response: GaxiosResponse<string>;
   try {
     response = await request<string>({
-      url: `https://raw.githubusercontent.com/${repository.organization}/${repository.name}/${repository.repository.default_branch}/README.md`,
+      url: `https://raw.githubusercontent.com/${repository.organization}/${repository.name}/${repository.baseBranch}/README.md`,
     });
   } catch (err) {
     logger.error(

--- a/src/sync.ts
+++ b/src/sync.ts
@@ -64,10 +64,10 @@ export async function sync(cli: meow.Result<typeof meowFlags>) {
     const cwd = path.join(rootPath, repo.name);
     return q.add(async () => {
       if (dirs.indexOf(repo.name) !== -1) {
-        await spawn('git reset --hard origin/master', {cwd});
-        await spawn('git checkout master', {cwd});
+        await spawn(`git reset --hard origin/${repo.baseBranch}`, {cwd});
+        await spawn(`git checkout ${repo.baseBranch}`, {cwd});
         await spawn('git fetch origin', {cwd});
-        await spawn('git reset --hard origin/master', {cwd});
+        await spawn(`git reset --hard origin/${repo.baseBranch}`, {cwd});
         orb.text = `[${i + 1}/${repos.length}] Synchronized ${repo.name}...`;
       } else {
         await spawn(`git clone ${cloneUrl}`, {cwd: rootPath});

--- a/src/update-prs.ts
+++ b/src/update-prs.ts
@@ -31,10 +31,10 @@ async function processMethod(repository: GitHubRepository, pr: PullRequest) {
 
   let latestCommit: {[index: string]: string};
   try {
-    latestCommit = await repository.getLatestCommitToMaster();
+    latestCommit = await repository.getLatestCommitToBaseBranch();
   } catch (err) {
     console.warn(
-      '    cannot get sha of latest commit to master, skipping:',
+      '    cannot get sha of latest commit to the base branch, skipping:',
       err.toString()
     );
     return false;
@@ -43,7 +43,7 @@ async function processMethod(repository: GitHubRepository, pr: PullRequest) {
   const latestMasterSha = latestCommit['sha'];
   if (latestMasterSha !== baseSha) {
     try {
-      await repository.updateBranch(ref, 'master');
+      await repository.updateBranch(ref, repository.baseBranch);
     } catch (err) {
       console.warn(
         `    cannot update branch for PR ${htmlUrl}, skipping:`,
@@ -62,7 +62,7 @@ export async function update(cli: meow.Result<typeof meowFlags>) {
     commandActive: 'updating',
     commandNamePastTense: 'updated',
     commandDesc:
-      'Iterates over all PRs matching the regex, and updates them, to the latest on master.',
+      'Iterates over all PRs matching the regex, and updates them, to the latest on the base branch.',
     processMethod,
   });
 }

--- a/test/github.ts
+++ b/test/github.ts
@@ -36,14 +36,6 @@ const testConfigSearch: Config = {
   repoSearch: 'a-search',
 };
 
-const testConfigBaseBranchOverride = {
-  githubToken: 'test-github-token',
-  clonePath: '',
-  repos: [
-    {org: 'test-organization', regex: 'matches', baseBranchOverride: 'main'},
-  ],
-};
-
 const url = 'https://api.github.com';
 let repo: GitHubRepository;
 
@@ -85,51 +77,6 @@ describe('GitHub', () => {
       ssh_url: 'git@github.com:test-organization/matches.git',
       default_branch: 'master',
     });
-    repo = repos[0];
-  });
-
-  it('should honor base branch override for a repo search', async () => {
-    const overrideConfig = Object.assign(testConfigSearch, {
-      baseBranchOverride: 'main',
-    });
-    const github = new GitHub(overrideConfig);
-    const path = '/search/repositories?per_page=100&page=1&q=a-search';
-    const full_name = 'test-organization/matches';
-    const default_branch = 'master';
-    const scope = nock(url)
-      .get(path)
-      .reply(200, {
-        items: [
-          {
-            full_name,
-            default_branch,
-          },
-        ],
-      });
-    const repos = await github.getRepositories();
-    scope.done();
-    assert.strictEqual(repos.length, 1);
-    assert.strictEqual(repos[0].baseBranch, overrideConfig.baseBranchOverride);
-    assert.strictEqual(repos[0].repository.default_branch, 'master');
-    repo = repos[0];
-  });
-
-  it('should honor a base branch override for individual repos', async () => {
-    const github = new GitHub(testConfigBaseBranchOverride as Config);
-    const path =
-      '/orgs/test-organization/repos?type=public&page=1&per_page=100';
-    const name = 'matches';
-    const owner = {login: 'test-organization'};
-    const scope = nock(url).get(path).reply(200, [{name, owner}]);
-    const repos = await github.getRepositories();
-    scope.done();
-    assert.strictEqual(repos.length, 1);
-    assert.notEqual(repos[0].baseBranch, undefined);
-    assert.notStrictEqual(repos[0].baseBranch, 'master');
-    assert.strictEqual(
-      repos[0].baseBranch,
-      testConfigBaseBranchOverride.repos[0].baseBranchOverride
-    );
     repo = repos[0];
   });
 

--- a/test/update-file.ts
+++ b/test/update-file.ts
@@ -84,6 +84,34 @@ describe('UpdateFile', () => {
       comment,
       reviewers,
       html_url: 'http://example.com/pulls/1',
+      base: 'master',
+    });
+  });
+
+  it('should target the base branch instead of master', async () => {
+    fakeGitHub.repository.testChangeBaseBranch('main');
+    fakeGitHub.repository.testSetFile(
+      'main',
+      path,
+      Buffer.from(originalContent).toString('base64')
+    );
+    await attemptUpdate();
+    assert.strictEqual(
+      fakeGitHub.repository.branches['main'][path]['content'],
+      Buffer.from(originalContent).toString('base64')
+    );
+    assert.strictEqual(
+      fakeGitHub.repository.branches[branch][path]['content'],
+      Buffer.from(changedContent).toString('base64')
+    );
+    assert.deepStrictEqual(fakeGitHub.repository.prs[1], {
+      number: 1,
+      branch,
+      message,
+      comment,
+      reviewers,
+      html_url: 'http://example.com/pulls/1',
+      base: 'main',
     });
   });
 
@@ -123,7 +151,7 @@ describe('UpdateFile', () => {
 
   it('should not update a file if cannot get master latest sha', async () => {
     const stub = sinon
-      .stub(fakeGitHub.repository, 'getLatestCommitToMaster')
+      .stub(fakeGitHub.repository, 'getLatestCommitToBaseBranch')
       .returns(Promise.reject(new Error('Random error')));
     await attemptUpdate();
     stub.restore();
@@ -199,6 +227,7 @@ describe('UpdateFile', () => {
       message,
       comment,
       html_url: 'http://example.com/pulls/1',
+      base: 'master',
     });
     stub.restore();
   });
@@ -307,6 +336,7 @@ describe('UpdateFile', () => {
       message,
       comment,
       html_url: 'http://example.com/pulls/1',
+      base: 'master',
     });
   });
 });


### PR DESCRIPTION
Fixes #442 🦕

This PR aims to add support for repositories with default branches names other than `master` (ex. `main`). The primary change made is replacing hardcoded references to `master` with the default branch of the repository as indicated by GitHub. As this behavior may not fit all applications, an optional `baseBranchOverride` key has also been added to the `config.yml` which will override the branch selection with a user specified value. Finally, several symbol names were changed to reflect new functionality, and tests were added to maintain coverage.