### PR TITLE
feat: add `replaceBranch` option to update-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ async function example() {
     path: 'path/to/file/in/repository',
     patchFunction: callbackFunction,
     branch: 'new-branch',
+    replaceBranch: false,
     message: 'commit message',
     comment: 'pull request comment',
     reviewers: ['github-username1', 'github-username2'],

--- a/src/lib/update-file.ts
+++ b/src/lib/update-file.ts
@@ -85,7 +85,9 @@ async function processRepository(
     if (replaceBranch) {
       try {
         await repository.deleteBranch(branch);
-      } catch {}
+      } catch {
+        //
+      }
     }
     await repository.createBranch(branch, latestSha);
   } catch (err) {

--- a/src/lib/update-file.ts
+++ b/src/lib/update-file.ts
@@ -38,6 +38,7 @@ async function processRepository(
   path: string,
   patchFunction: Function,
   branch: string,
+  replaceBranch: boolean,
   message: string,
   comment: string,
   reviewers: string[]
@@ -81,6 +82,11 @@ async function processRepository(
   const latestSha = latestCommit['sha'];
 
   try {
+    if (replaceBranch) {
+      try {
+        await repository.deleteBranch(branch);
+      } catch {}
+    }
     await repository.createBranch(branch, latestSha);
   } catch (err) {
     console.warn(
@@ -139,6 +145,7 @@ export interface UpdateFileOptions {
   path: string;
   patchFunction: Function;
   branch: string;
+  replaceBranch: boolean;
   message: string;
   comment: string;
   reviewers: string[];
@@ -154,6 +161,7 @@ export interface UpdateFileOptions {
  * @param {patchFunction} options.patchFunction Callback function that should modify the
  * file.
  * @param {string} options.branch Name for a new branch to use.
+ * @param {boolean} options.replaceBranch Delete the branch first.
  * @param {string} options.message Commit message and pull request title.
  * @param {string} options.comment Pull request body.
  * @param {string[]} options.reviewers Reviewers' GitHub logins for the pull request.
@@ -178,6 +186,7 @@ export async function updateFile(options: UpdateFileOptions) {
 
   const comment = options.comment || '';
   const reviewers = options.reviewers || [];
+  const replaceBranch = !!options.replaceBranch;
 
   const config = await getConfig();
   const github = new GitHub(config);
@@ -189,6 +198,7 @@ export async function updateFile(options: UpdateFileOptions) {
       options.path,
       options.patchFunction,
       options.branch,
+      replaceBranch,
       options.message,
       comment,
       reviewers


### PR DESCRIPTION
Thanks for the great tool!

I needed to hack it locally to delete a branch before creating a new one after I made a mistake, and thought it might be useful in the project itself.

This doesn't add any tests because I don't have time right now, so feel free to close if that's a requirement and I might come back to that in the future.