### PR TITLE
fix: fetch all branches during sync

### DIFF
--- a/src/sync.ts
+++ b/src/sync.ts
@@ -64,6 +64,7 @@ export async function sync(cli: meow.Result<typeof meowFlags>) {
     const cwd = path.join(rootPath, repo.name);
     return q.add(async () => {
       if (dirs.indexOf(repo.name) !== -1) {
+        await spawn('git fetch --all', {cwd});
         await spawn(`git reset --hard origin/${repo.baseBranch}`, {cwd});
         await spawn(`git checkout ${repo.baseBranch}`, {cwd});
         await spawn('git fetch origin', {cwd});


### PR DESCRIPTION
Locally, I was getting errors during the `git reset` phase of `repo sync`.  The cause was an older repo that was cached.  It had a `master` branch, but the default branch had been renamed to `main`.  By first fetching all branches, we are sure the one we'll need will be available. 