### PR TITLE
feat(list): allow PRs to be filtered by label

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,7 +74,7 @@ const cli = meow(
 	  $ repo <command>
 
   Examples
-    $ repo list [--branch branch] [--author author] [--title title]
+    $ repo list [--branch branch] [--author author] [--title title] [--label]
     $ repo list-issues [--branch branch] [--author author] [--title title] [--body body]
     $ repo approve [--branch branch] [--author author] [--title title]
     $ repo update [--branch branch] [--author author] [--title title]

--- a/src/lib/asyncItemIterator.ts
+++ b/src/lib/asyncItemIterator.ts
@@ -55,15 +55,22 @@ async function process(
   options: PRIteratorOptions | IssueIteratorOptions,
   processIssues = false
 ) {
-  if (!cli.flags.title && !cli.flags.branch && !cli.flags.body) {
+  if (
+    !cli.flags.title &&
+    !cli.flags.branch &&
+    !cli.flags.body &&
+    !cli.flags.label
+  ) {
     console.log(
       `Usage: repo ${
         options.commandName
-      } [--branch branch] [--title title] [--body body] ${options?.additionalFlags?.join(
+      } [--branch branch] [--title title] [--body body] [--label label] ${options?.additionalFlags?.join(
         ' '
       )}`
     );
-    console.log('Either branch name, body, or title regex must present.');
+    console.log(
+      'Either branch name, body, label, or title regex must present.'
+    );
     console.log(options.commandDesc);
     return;
   }
@@ -125,6 +132,15 @@ async function process(
     items = items.filter(itemSet => {
       const pr = itemSet.item as PullRequest;
       return new RegExp(cli.flags.branch as string).test(pr.head.ref);
+    });
+  }
+  if (cli.flags.label) {
+    console.log(`Label scan: ${cli.flags.label}`);
+    items = items.filter(itemSet => {
+      const pr = itemSet.item as PullRequest;
+      return pr.labels.some(label => {
+        return new RegExp(cli.flags.label as string).test(label.name);
+      });
     });
   }
   if (cli.flags.body) {

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -661,6 +661,9 @@ export interface PullRequest extends Issue {
   patch_url: string;
   base: {sha: string};
   head: {ref: string; label: string; repo: Repository};
+  labels: Array<{
+    name: string;
+  }>;
 }
 
 export interface Issue {


### PR DESCRIPTION
Allow PRs to be filtered by label, this makes it easier to identify PRs such as [this](https://github.com/googleapis/nodejs-service-control/pull/40).

```
$ node ./build/src/cli.js list --label="owl-bot-copy"
Loaded 134 repositories from JSON config.
Total 134 unique repositories loaded.
⠋ [133/134] Scanning repos for PRsLabel scan: owl-bot-copy
✔ [134/134] repositories scanned, 2 matching PRs found
✔ [2/2] PRs listed
Successfully processed: 2 PRs
  https://github.com/googleapis/nodejs-dialogflow-cx/pull/138  docs: added notes to train agent before sending queries
  https://github.com/googleapis/nodejs-service-control/pull/40 fix: GoogleAdsError missing using generator version after 1.3.0
```