### PR TITLE
feat: introduce retry and delay configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,3 +289,27 @@ A promisified version of `readline.question` to provide some primitive
 interaction.
 
 ## Handling large numbers of repositories
+
+If you are running GitHub Repo Automation against a large number of repositories, you may find that
+the default settings lead to quota issues.
+
+There are settings you can configure to make this less likely:
+
+1. Set `--concurrency=N` to reduce the # of concurrent requests you are performing:
+  ```bash
+  repo approve --concurrency=4 --title='.*foo dep.*'
+  ```
+2. Set `--retry` to automatically retry exceptions with an exponential backoff:
+  ```
+  repo approve --retry --title='.*foo dep.*'
+  ```
+3. Set `--delay=N` to introduce a delay between requests, allowing you to spread out operations over a longer timeframe:
+  ```
+  repo approve --delay=2500
+  ```
+
+When running against a large number of repos, try the following as a starting point:
+
+```bash
+repo [command] --delay=2500 --concurrency=4 --retry --title='.*some title.*'
+```

--- a/README.md
+++ b/README.md
@@ -287,3 +287,5 @@ pass less parameters to each API call.
 
 A promisified version of `readline.question` to provide some primitive
 interaction.
+
+## Handling large numbers of repositories

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -63,6 +63,9 @@ export const meowFlags: {
   delay: {
     type: 'number',
   },
+  retry: {
+    type: 'boolean',
+  },
   auto: {type: 'boolean'},
   concurrency: {type: 'string'},
   author: {type: 'string'},

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,7 +34,7 @@ const pkg = require('../../package.json');
 updateNotifier({pkg}).notify();
 
 export const meowFlags: {
-  [key: string]: {type: 'string' | 'boolean'; alias?: string};
+  [key: string]: {type: 'string' | 'boolean' | 'number'; alias?: string};
 } = {
   branch: {
     type: 'string',
@@ -59,6 +59,9 @@ export const meowFlags: {
   title: {
     type: 'string',
     alias: 't',
+  },
+  delay: {
+    type: 'number',
   },
   auto: {type: 'boolean'},
   concurrency: {type: 'string'},

--- a/src/lib/asyncItemIterator.ts
+++ b/src/lib/asyncItemIterator.ts
@@ -162,7 +162,9 @@ async function process(
   const github = new GitHub(config);
   const regex = new RegExp((cli.flags.title as string) || '.*');
   const bodyRe = new RegExp((cli.flags.body as string) || '.*');
-  const repos = await github.getRepositories();
+  const repos = await retryException<GitHubRepository[]>(() => {
+    return github.getRepositories();
+  }, retryStrategy);
   const successful: Issue[] = [];
   const failed: Issue[] = [];
   let error: string | undefined;

--- a/src/lib/asyncItemIterator.ts
+++ b/src/lib/asyncItemIterator.ts
@@ -75,10 +75,10 @@ async function retryBoolean(
 
 /*
  * Propose next delay, introducing some jitter.
- * @param {number[]} retryStrategy array of retry intervals.
+ * @param {number} base delay.
  */
 function nextDelay(base: number) {
-  return base;
+  return base + (base / 4) * Math.random();
 }
 
 /**
@@ -266,7 +266,7 @@ async function process(
           if (processIssues) {
             const opts = options as IssueIteratorOptions;
             result = await retryBoolean(async () => {
-              if (delay) delayMs(delay);
+              if (delay) await delayMs(delay);
               return await opts.processMethod(
                 itemSet.repo,
                 itemSet.item as Issue,
@@ -276,7 +276,7 @@ async function process(
           } else {
             const opts = options as PRIteratorOptions;
             result = await retryBoolean(async () => {
-              if (delay) delayMs(delay);
+              if (delay) await delayMs(delay);
               return await opts.processMethod(
                 itemSet.repo,
                 itemSet.item as PullRequest,

--- a/src/lib/asyncItemIterator.ts
+++ b/src/lib/asyncItemIterator.ts
@@ -39,7 +39,6 @@ async function retryException<T>(
       if (i < retryStrategy.length) {
         console.error(`operation failed: ${err.toString()}`);
         const delay = nextDelay(retryStrategy[i - 1]);
-        console.info(`retry in ${delay}ms`);
         await delayMs(delay);
         continue;
       }
@@ -64,7 +63,6 @@ async function retryBoolean(
     if (!result && i < retryStrategy.length) {
       const delay = nextDelay(retryStrategy[i - 1]);
       await delayMs(delay);
-      console.info(`retry in ${delay}ms`);
       continue;
     } else {
       return result;
@@ -86,6 +84,7 @@ function nextDelay(base: number) {
  * @param {number} ms ms to delay.
  */
 function delayMs(ms: number) {
+  console.info(`\rdelay ${ms}ms\r`);
   return new Promise(resolve => {
     setTimeout(() => {
       resolve(undefined);

--- a/src/lib/asyncItemIterator.ts
+++ b/src/lib/asyncItemIterator.ts
@@ -37,8 +37,8 @@ async function retryException<T>(
       return result;
     } catch (err) {
       if (i < retryStrategy.length) {
-        console.error(`operation failed: ${err.toString()}`);
-        const delay = nextDelay(retryStrategy[i - 1]);
+        console.error(`\noperation failed: ${err.toString()}`);
+        const delay = nextDelay(retryStrategy[i]);
         await delayMs(delay);
         continue;
       }
@@ -61,7 +61,7 @@ async function retryBoolean(
   for (let i = 0; i <= retryStrategy.length; i++) {
     const result = await eventual();
     if (!result && i < retryStrategy.length) {
-      const delay = nextDelay(retryStrategy[i - 1]);
+      const delay = nextDelay(retryStrategy[i]);
       await delayMs(delay);
       continue;
     } else {
@@ -84,7 +84,7 @@ function nextDelay(base: number) {
  * @param {number} ms ms to delay.
  */
 function delayMs(ms: number) {
-  console.info(`\rdelay ${ms}ms\r`);
+  console.info(`\nwait ${ms}ms`);
   return new Promise(resolve => {
     setTimeout(() => {
       resolve(undefined);

--- a/src/lib/asyncItemIterator.ts
+++ b/src/lib/asyncItemIterator.ts
@@ -39,6 +39,7 @@ async function retryException<T>(
       if (i < retryStrategy.length) {
         console.error(`\noperation failed: ${err.toString()}`);
         const delay = nextDelay(retryStrategy[i]);
+        console.info(`\nretrying in ${delay}ms`);
         await delayMs(delay);
         continue;
       }
@@ -62,6 +63,7 @@ async function retryBoolean(
     const result = await eventual();
     if (!result && i < retryStrategy.length) {
       const delay = nextDelay(retryStrategy[i]);
+      console.info(`\nretrying in ${delay}ms`);
       await delayMs(delay);
       continue;
     } else {
@@ -84,7 +86,6 @@ function nextDelay(base: number) {
  * @param {number} ms ms to delay.
  */
 function delayMs(ms: number) {
-  console.info(`\nwait ${ms}ms`);
   return new Promise(resolve => {
     setTimeout(() => {
       resolve(undefined);
@@ -153,10 +154,11 @@ async function process(
   // Introduce a delay between requests, this may be necessary if
   // processing many repos in a row to avoid rate limits:
   const delay: number = cli.flags.delay ? Number(cli.flags.delay) : 0;
+  const retry: boolean = cli.flags.retry ? Boolean(cli.flags.retry) : false;
   const config = await configLib.getConfig();
-  const retryStrategy = config.retryStrategy ?? [
-    3000, 6000, 15000, 30000, 60000,
-  ];
+  const retryStrategy = retry
+    ? config.retryStrategy ?? [3000, 6000, 15000, 30000, 60000]
+    : [];
   const github = new GitHub(config);
   const regex = new RegExp((cli.flags.title as string) || '.*');
   const bodyRe = new RegExp((cli.flags.body as string) || '.*');

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -64,4 +64,5 @@ export interface Config {
     }
   ];
   repoSearch?: string;
+  retryStrategy?: Array<number>;
 }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -19,10 +19,21 @@
 import {Gaxios} from 'gaxios';
 import {Config} from './config';
 
-function getClient(config: Config) {
+export function getClient(config: Config) {
   return new Gaxios({
     baseURL: 'https://api.github.com',
     headers: {Authorization: `token ${config.githubToken}`},
+    retryConfig: {
+      retry: 10,
+      retryDelay: 3000,
+      shouldRetry: () => true,
+      onRetryAttempt: err => {
+        console.warn(`\n${err.message}`);
+        console.info(
+          `retrying ${err.config.url} attempt ${err.config.retryConfig?.currentRetryAttempt}`
+        );
+      },
+    },
   });
 }
 

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -23,17 +23,6 @@ export function getClient(config: Config) {
   return new Gaxios({
     baseURL: 'https://api.github.com',
     headers: {Authorization: `token ${config.githubToken}`},
-    retryConfig: {
-      retry: 10,
-      retryDelay: 3000,
-      shouldRetry: () => true,
-      onRetryAttempt: err => {
-        console.warn(`\n${err.message}`);
-        console.info(
-          `retrying ${err.config.url} attempt ${err.config.retryConfig?.currentRetryAttempt}`
-        );
-      },
-    },
   });
 }
 

--- a/test/async-iterator.ts
+++ b/test/async-iterator.ts
@@ -44,6 +44,7 @@ describe('asyncItemIterator', () => {
     const cli = {
       flags: {
         title: '.*',
+        retry: true,
       },
     } as unknown as meow.Result<typeof meowFlags>;
     const githubRequests = nock('https://api.github.com')
@@ -87,6 +88,7 @@ describe('asyncItemIterator', () => {
     const cli = {
       flags: {
         title: '.*',
+        retry: true,
       },
     } as unknown as meow.Result<typeof meowFlags>;
     const githubRequests = nock('https://api.github.com')

--- a/test/async-iterator.ts
+++ b/test/async-iterator.ts
@@ -1,0 +1,131 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @fileoverview Unit tests for lib/asyncItemIterator.js.
+ */
+
+import * as assert from 'assert';
+import meow = require('meow');
+import {meowFlags} from '../src/cli';
+import {describe, it} from 'mocha';
+import * as nock from 'nock';
+import * as sinon from 'sinon';
+
+import {GitHubRepository, PullRequest} from '../src/lib/github';
+import * as config from '../src/lib/config';
+import {processPRs} from '../src/lib/asyncItemIterator';
+
+nock.disableNetConnect();
+
+describe('asyncItemIterator', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+  it('should retry list operation on failure', async () => {
+    sinon.stub(config, 'getConfig').resolves({
+      githubToken: 'abc123',
+      clonePath: '/foo/bar',
+      retryStrategy: [5, 10, 20],
+      repoSearch:
+        'org:googleapis language:typescript language:javascript is:public archived:false',
+    });
+    const cli = {
+      flags: {
+        title: '.*',
+      },
+    } as unknown as meow.Result<typeof meowFlags>;
+    const githubRequests = nock('https://api.github.com')
+      .get(
+        '/search/repositories?per_page=100&page=1&q=org%3Agoogleapis%20language%3Atypescript%20language%3Ajavascript%20is%3Apublic%20archived%3Afalse'
+      )
+      .reply(200, {
+        items: [
+          {
+            full_name: 'googleapis/foo',
+            default_branch: 'main',
+          },
+        ],
+      })
+      .get('/repos/googleapis/foo/pulls?state=open&page=1')
+      .reply(403)
+      .get('/repos/googleapis/foo/pulls?state=open&page=1')
+      .reply(403)
+      .get('/repos/googleapis/foo/pulls?state=open&page=1')
+      .reply(200);
+    await processPRs(cli, {
+      commandName: 'update',
+      commandActive: 'updating',
+      commandNamePastTense: 'updated',
+      commandDesc:
+        'Iterates over all PRs matching the regex, and updates them, to the latest on the base branch.',
+      processMethod: async () => {
+        return true;
+      },
+    });
+    githubRequests.done();
+  });
+  it('should retry process method if it returns false', async () => {
+    sinon.stub(config, 'getConfig').resolves({
+      githubToken: 'abc123',
+      clonePath: '/foo/bar',
+      retryStrategy: [5, 10, 20],
+      repoSearch:
+        'org:googleapis language:typescript language:javascript is:public archived:false',
+    });
+    const cli = {
+      flags: {
+        title: '.*',
+      },
+    } as unknown as meow.Result<typeof meowFlags>;
+    const githubRequests = nock('https://api.github.com')
+      .get(
+        '/search/repositories?per_page=100&page=1&q=org%3Agoogleapis%20language%3Atypescript%20language%3Ajavascript%20is%3Apublic%20archived%3Afalse'
+      )
+      .reply(200, {
+        items: [
+          {
+            full_name: 'googleapis/foo',
+            default_branch: 'main',
+          },
+        ],
+      })
+      .get('/repos/googleapis/foo/pulls?state=open&page=1')
+      .reply(200, [
+        {
+          title: 'feat: foo pull request',
+          html_url: 'http://example.com/pr/2',
+        },
+      ])
+      .get('/repos/googleapis/foo/pulls?state=open&page=2')
+      .reply(200);
+    let retryCount = 0;
+    await processPRs(cli, {
+      commandName: 'update',
+      commandActive: 'updating',
+      commandNamePastTense: 'updated',
+      commandDesc:
+        'Iterates over all PRs matching the regex, and updates them, to the latest on the base branch.',
+      processMethod: async (repository: GitHubRepository, pr: PullRequest) => {
+        assert.strictEqual(repository.name, 'foo');
+        assert.strictEqual(pr.html_url, 'http://example.com/pr/2');
+        retryCount++;
+        if (retryCount > 2) return true;
+        else return false;
+      },
+    });
+    assert.strictEqual(retryCount, 3);
+    githubRequests.done();
+  });
+});

--- a/test/github.ts
+++ b/test/github.ts
@@ -20,15 +20,7 @@ import * as assert from 'assert';
 import {describe, it} from 'mocha';
 import * as nock from 'nock';
 import {Config} from '../src/lib/config';
-import {GitHub, GitHubRepository, Repository} from '../src/lib/github';
-import {Gaxios} from 'gaxios';
-
-function getClient(config: Config) {
-  return new Gaxios({
-    baseURL: 'https://api.github.com',
-    headers: {Authorization: `token ${config.githubToken}`},
-  });
-}
+import {getClient, GitHub, GitHubRepository, Repository} from '../src/lib/github';
 
 nock.disableNetConnect();
 
@@ -186,6 +178,36 @@ describe('GitHubRepository', () => {
     const path = '/repos/test-organization/test-repo/branches/test-branch';
     const ref = 'refs/heads/test-branch';
     const scope = nock(url).get(path).reply(200, {ref});
+    const branch = await repo.getBranch('test-branch');
+    scope.done();
+    assert.deepEqual(branch, {ref});
+  });
+
+  it.only('should retry on exception', async function () {
+    this.timeout(200000)
+    const testingClient = getClient(testConfig);
+    const repo = new GitHubRepository(
+      testingClient,
+      testRepo,
+      'test-organization'
+    );
+    const path = '/repos/test-organization/test-repo/branches/test-branch';
+    const ref = 'refs/heads/test-branch';
+    const scope = nock(url)
+      .get(path).reply(403, {ref})
+      .get(path).reply(403, {ref})
+      .get(path).reply(403, {ref})
+      .get(path).reply(403, {ref})
+      .get(path).reply(403, {ref})
+      .get(path).reply(403, {ref})
+      .get(path).reply(403, {ref})
+      .get(path).reply(403, {ref})
+      .get(path).reply(403, {ref})
+      .get(path).reply(403, {ref})
+      .get(path).reply(403, {ref})
+      .get(path).reply(403, {ref})
+      .get(path).reply(403, {ref})
+    ;
     const branch = await repo.getBranch('test-branch');
     scope.done();
     assert.deepEqual(branch, {ref});

--- a/test/github.ts
+++ b/test/github.ts
@@ -20,7 +20,12 @@ import * as assert from 'assert';
 import {describe, it} from 'mocha';
 import * as nock from 'nock';
 import {Config} from '../src/lib/config';
-import {getClient, GitHub, GitHubRepository, Repository} from '../src/lib/github';
+import {
+  getClient,
+  GitHub,
+  GitHubRepository,
+  Repository,
+} from '../src/lib/github';
 
 nock.disableNetConnect();
 
@@ -178,36 +183,6 @@ describe('GitHubRepository', () => {
     const path = '/repos/test-organization/test-repo/branches/test-branch';
     const ref = 'refs/heads/test-branch';
     const scope = nock(url).get(path).reply(200, {ref});
-    const branch = await repo.getBranch('test-branch');
-    scope.done();
-    assert.deepEqual(branch, {ref});
-  });
-
-  it.only('should retry on exception', async function () {
-    this.timeout(200000)
-    const testingClient = getClient(testConfig);
-    const repo = new GitHubRepository(
-      testingClient,
-      testRepo,
-      'test-organization'
-    );
-    const path = '/repos/test-organization/test-repo/branches/test-branch';
-    const ref = 'refs/heads/test-branch';
-    const scope = nock(url)
-      .get(path).reply(403, {ref})
-      .get(path).reply(403, {ref})
-      .get(path).reply(403, {ref})
-      .get(path).reply(403, {ref})
-      .get(path).reply(403, {ref})
-      .get(path).reply(403, {ref})
-      .get(path).reply(403, {ref})
-      .get(path).reply(403, {ref})
-      .get(path).reply(403, {ref})
-      .get(path).reply(403, {ref})
-      .get(path).reply(403, {ref})
-      .get(path).reply(403, {ref})
-      .get(path).reply(403, {ref})
-    ;
     const branch = await repo.getBranch('test-branch');
     scope.done();
     assert.deepEqual(branch, {ref});


### PR DESCRIPTION
Introduces retrying with exponential backoff, and delay.

---

If you are running GitHub Repo Automation against a large number of repositories, you may find that
the default settings lead to quota issues.

There are settings you can configure to make this less likely:

1. Set `--concurrency=N` to reduce the # of concurrent requests you are performing:
  ```bash
  repo approve --concurrency=4 --title='.*foo dep.*'
  ```
2. Set `--retry` to automatically retry exceptions with an exponential backoff:
  ```
  repo approve --retry --title='.*foo dep.*'
  ```
3. Set `--delay=N` to introduce a delay between requests, allowing you to spread out operations over a longer timeframe:
  ```
  repo approve --delay=2500
  ```

When running against a large number of repos, try the following as a starting point:

```bash
repo [command] --delay=2500 --concurrency=4 --retry --title='.*some title.*'
```

Refs: #556 