### PR TITLE
feat: delay by default

### DIFF
--- a/src/lib/asyncItemIterator.ts
+++ b/src/lib/asyncItemIterator.ts
@@ -153,7 +153,7 @@ async function process(
     : 15;
   // Introduce a delay between requests, this may be necessary if
   // processing many repos in a row to avoid rate limits:
-  const delay: number = cli.flags.delay ? Number(cli.flags.delay) : 0;
+  const delay: number = cli.flags.delay ? Number(cli.flags.delay) : 500;
   const retry: boolean = cli.flags.retry ? Boolean(cli.flags.retry) : false;
   const config = await configLib.getConfig();
   const retryStrategy = retry
@@ -187,12 +187,12 @@ async function process(
           let localItems;
           if (processIssues) {
             localItems = await retryException<Issue[]>(async () => {
-              if (delay) delayMs(delay);
+              if (delay) delayMs(nextDelay(delay));
               return await repo.listIssues();
             }, retryStrategy);
           } else {
             localItems = await retryException<PullRequest[]>(async () => {
-              if (delay) delayMs(delay);
+              if (delay) delayMs(nextDelay(delay));
               return await repo.listPullRequests();
             }, retryStrategy);
           }
@@ -266,7 +266,7 @@ async function process(
           if (processIssues) {
             const opts = options as IssueIteratorOptions;
             result = await retryBoolean(async () => {
-              if (delay) await delayMs(delay);
+              if (delay) await delayMs(nextDelay(delay));
               return await opts.processMethod(
                 itemSet.repo,
                 itemSet.item as Issue,
@@ -276,7 +276,7 @@ async function process(
           } else {
             const opts = options as PRIteratorOptions;
             result = await retryBoolean(async () => {
-              if (delay) await delayMs(delay);
+              if (delay) await delayMs(nextDelay(delay));
               return await opts.processMethod(
                 itemSet.repo,
                 itemSet.item as PullRequest,


### PR DESCRIPTION
## Background

Having done some testing, I'm pretty convinced it's unlikely users are easily hitting the 5000 request per-hour quota. I think what's instead happening is a secondary quota that occurs, either:

* due to too many concurrent requests (which can be controlled with `--concurrency`), or.
* due to too many requests in a short period of time (perhaps due to fast home Internet?), or.
* perhaps some ISPs are themselves triggering a 403?

## In pursuit of unblocking people

1. this PR defaults the delay between requests to `500ms`, and introduces a jitter, such that even when running requests in parallel there should be some separation between them.
2. #563 introduces retry logic (enabled via `--retry`) which when turned on will retry spurious 403s several times. It also documents `--concurrency` which I recommend adjusting to see if 403s stop cropping up.
3. #567 adds logging of GitHub ratelimit headers, enabled via `NODE_DEBUG=repo repo foo`, I suggest users bumping into issues set this environment variable to confirm the hypothesis about the source of 403s.

Refs: #556 