### PR TITLE
feat: use cache when listing PRs and issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@types/command-line-usage": "^5.0.2",
     "@types/tmp": "^0.2.3",
+    "async-mutex": "^0.3.2",
     "chalk": "^5.0.1",
     "command-line-usage": "^6.1.3",
     "extend": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "nock": "^13.2.9",
     "proxyquire": "^2.1.3",
     "sinon": "^14.0.0",
-    "typescript": "^4.7.4"
+    "typescript": "~4.7.4"
   },
   "scripts": {
     "lint": "gts check",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -97,6 +97,7 @@ const cli = meow(
       concurrency: {type: 'string'},
       author: {type: 'string'},
       yespleasedoit: {type: 'boolean'},
+      nocache: {type: 'boolean'},
     },
   }
 );

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -102,3 +102,16 @@ export async function saveToCache(
     unlock();
   }
 }
+
+export async function deleteCache(repo: GitHubRepository, type: CacheType) {
+  try {
+    await lock();
+    await initCache();
+    const cacheFile = cacheFilename(repo, type);
+    if (existsSync(cacheFile)) {
+      await unlink(cacheFile);
+    }
+  } finally {
+    unlock();
+  }
+}

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -1,0 +1,104 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import {existsSync} from 'fs';
+import {mkdir, readFile, stat, unlink, writeFile} from 'fs/promises';
+import {tmpdir} from 'os';
+import {join} from 'path';
+import {GitHubRepository, Issue, PullRequest} from './github';
+
+const cacheDirectory = join(tmpdir(), 'google-repo-cache');
+const cacheMaxAge = 60 * 60 * 1000; // 1 hour
+
+export type CachedData = {issues?: Issue[]; prs?: PullRequest[]};
+export type CacheType = 'prs' | 'issues';
+
+// Quick'n'dirty mutex implementation, because it spawns multiple workers
+function sleep(interval: number) {
+  return new Promise(resolve => setTimeout(resolve, interval));
+}
+
+let locked = false;
+
+async function lock() {
+  while (locked) {
+    await sleep(Math.random() * 100);
+  }
+  locked = true;
+}
+
+function unlock() {
+  locked = false;
+}
+
+async function initCache() {
+  if (!existsSync(cacheDirectory)) {
+    await mkdir(cacheDirectory);
+  }
+}
+
+function cacheFilename(repo: GitHubRepository, type: CacheType) {
+  const owner = repo.repository.owner.login;
+  const name = repo.repository.name;
+  return join(
+    cacheDirectory,
+    `${owner}-${name}`.replace(/\W/g, '-') + `-${type}`
+  );
+}
+
+export async function readFromCache(repo: GitHubRepository, type: CacheType) {
+  try {
+    await lock();
+    await initCache();
+    const cacheFile = cacheFilename(repo, type);
+    if (!existsSync(cacheFile)) {
+      return null;
+    }
+    const cacheStat = await stat(cacheFile);
+    const mtime = cacheStat.mtimeMs ?? cacheStat.ctimeMs;
+    const now = Date.now();
+    if (now - mtime >= cacheMaxAge) {
+      await unlink(cacheFile);
+      return null;
+    }
+
+    const content = await readFile(cacheFile);
+    const json = JSON.parse(content.toString()) as CachedData;
+    return json;
+  } finally {
+    unlock();
+  }
+}
+
+export async function saveToCache(
+  repo: GitHubRepository,
+  type: CacheType,
+  data: CachedData
+) {
+  try {
+    await lock();
+    await initCache();
+    const cacheFile = cacheFilename(repo, type);
+    if (!data.issues) {
+      data.issues = [];
+    }
+    if (!data.prs) {
+      data.prs = [];
+    }
+    const content = JSON.stringify(data, null, '  ');
+    await writeFile(cacheFile, content);
+  } finally {
+    unlock();
+  }
+}

--- a/test/async-iterator.ts
+++ b/test/async-iterator.ts
@@ -44,6 +44,7 @@ describe('asyncItemIterator', () => {
       flags: {
         title: '.*',
         retry: true,
+        nocache: true,
       },
     } as unknown as ReturnType<typeof meow>;
     const githubRequests = nock('https://api.github.com')
@@ -88,6 +89,7 @@ describe('asyncItemIterator', () => {
       flags: {
         title: '.*',
         retry: true,
+        nocache: true,
       },
     } as unknown as ReturnType<typeof meow>;
     const githubRequests = nock('https://api.github.com')


### PR DESCRIPTION
We have 167 repositories matching my filters at this moment. Quite often, I need to do several things one after one, e.g. first tag all matching PRs, then approve. Listing across 167 repositories every time is painful, takes time, and consumes quota.

Let's cache everything for 1 hour. The break glass `--nocache` option is also provided.