### PR TITLE
docs: Add Link for Github Token Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ your `PATH`, and install the required dependencies:
 $ npm install -g @google/repo
 ```
 
-You need to make your own [`config.yaml`](https://github.com/googleapis/github-repo-automation/blob/main/config.yaml.default) and put your GitHub token there. Example:
+You need to make your own [`config.yaml`](https://github.com/googleapis/github-repo-automation/blob/main/config.yaml.default) and put your [GitHub token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) there. Example:
 
 ```
 baseUrl: https://git.mycompany.com/api/v3 # optional, if you are using GitHub Enterprise


### PR DESCRIPTION
🦕
