### PR TITLE
docs: mark this repository as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**_THIS REPOSITORY IS DEPRECATED._**
+
 <img src="https://avatars0.githubusercontent.com/u/1342004?v=3&s=96" alt="Google Inc. logo" title="Google" align="right" height="96" width="96"/>
 
 # GitHub Repo Automation


### PR DESCRIPTION
We no longer use this tool on a regular basis.
